### PR TITLE
enhance POJO detection

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as vm from 'vm';
 import devalue from '../src/index';
 
 describe('devalue', () => {
@@ -80,5 +81,17 @@ describe('devalue', () => {
 		// let arr = [];
 		// arr.x = 42;
 		// test('Array with named properties', arr, `TODO`);
+
+		test('cross-realm POJO', vm.runInNewContext('({})'), '{}');
+
+		it('throws for non-POJOs', () => {
+			class Foo {}
+			const foo = new Foo();
+			assert.throws(() => devalue(foo));
+		});
+
+		it('throws for symbolic keys', () => {
+			assert.throws(() => devalue({ [Symbol()]: null }));
+		});
 	});
 });


### PR DESCRIPTION
Mostly fixes #5. I'm pretty sure it's impossible to be 100% certain that something is a POJO from another realm, but this seems to be a reasonable approximation of that.

This also throws if any of the keys on the object are symbols.

It does not handle non-enumerable keys or things with non-default property descriptors.