### PR TITLE
duplicate parameter name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ function getName(num: number) {
 		num = ~~(num / chars.length) - 1;
 	} while (num >= 0);
 
-	return reserved.test(name) ? `${name}_` : name;
+	return reserved.test(name) ? `${name}0` : name;
 }
 
 function isPrimitive(thing: any) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -118,5 +118,13 @@ describe('devalue', () => {
 		it('throws for symbolic keys', () => {
 			assert.throws(() => devalue({ [Symbol()]: null }));
 		});
+
+		it('do not have duplicates in generated argument names', () => {
+			const foo = new Array(20000).fill(0).map((_, i) => i);
+			const bar = foo.map((_, i) => ({ [i]: foo[i] }));
+			const serialized = devalue([foo, ...bar]);
+
+			assert.doesNotThrow(() => eval(serialized), /Duplicate parameter name/);
+		});
 	});
 });


### PR DESCRIPTION
Hi,

I've noticed that serialization of a large number of variables can lead to unexpected problems because `getName` function can produce duplicates:
- `getName(230)` =>`do_`; (reserved word `do` + `_` suffix)
- `getName(12526)` => `do_`; (created "regularly")

Using any number as a suffix to alter reserved word is safe:
- number won't be at the beginning of an identifier
- numbers are not included in `chars` that are used to generate names, so no risk of duplicates