### PR TITLE
remove RunKit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Like `JSON.stringify`, but handles
 - `Map` and `Set`
 - `BigInt`
 
-Try it out on [runkit.com](https://npm.runkit.com/devalue).
-
 ## Goals:
 
 - Performance


### PR DESCRIPTION
RunKit does not support ESM modules, apparently, so there's no sense in linking to it here. I'm not sure in 2022 what could quite function as click-and-go-try-it-out replacement for this sort of thing. In the meantime, we were probably due to remove the RunKit link anyway.

It should also be removed as the homepage for this repo.