### PR TITLE
remove old `devalue` export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,3 @@
 export { uneval } from './src/uneval.js';
 export { parse } from './src/parse.js';
 export { stringify } from './src/stringify.js';
-
-export function devalue() {
-	throw new Error(
-		'The `devalue` export has been removed. Use `uneval` instead'
-	);
-}


### PR DESCRIPTION
As briefly discussed on Discord, there is a trade-off here.

Unfortunately, we can't have a friendly compile-time error for users' apps if they're still using the `devalue` export, so in 4.0.0 devalue opted for a friendly runtime error. I'd argue, though, that a broken app successfully building is worse than the build failing, even if the error doesn't tell you exactly what you need to change.