### PR TITLE
Add oson to See also section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Using `new Function(code)` is akin to using indirect eval.
 
 - [lave](https://github.com/jed/lave) by Jed Schmidt
 - [arson](https://github.com/benjamn/arson) by Ben Newman. The `stringify`/`parse` approach in `devalue` was inspired by `arson`
+- [oson](https://github.com/KnorpelSenf/oson) by Steffen Trog
 - [tosource](https://github.com/marcello3d/node-tosource) by Marcello Bastéa-Forte
 - [serialize-javascript](https://github.com/yahoo/serialize-javascript) by Eric Ferraiuolo
 - [jsesc](https://github.com/mathiasbynens/jsesc) by Mathias Bynens


### PR DESCRIPTION
This README has a very nice list that references similar libraries. I created yet another one of those JSON substitutes. It does stuff that nobody else does, so with this pull request I'd like to update your list.