### PR TITLE
Throw syntax errors when parsing invalid input

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -14,18 +14,23 @@ import {
 export function parse(serialized) {
 	const parsed = JSON.parse(serialized);
 
-	if (typeof parsed === 'number') return hydrate(parsed);
+	if (typeof parsed === 'number') {
+		const constant = hydrateConstant(parsed);
+		if (constant === NOT_A_CONSTANT) throw new SyntaxError(`Unexpected number ${parsed}`);
+		return constant;
+	}
+
+	if (!Array.isArray(parsed)) throw new SyntaxError(`Expected array, got ${parsed === null ? 'null' : typeof parsed}`);
 
 	const values = /** @type {any[]} */ (parsed);
+	if (values.length === 0) throw new SyntaxError(`Unexpected empty array`);
+
 	const hydrated = Array(values.length);
 
 	/** @param {number} index */
 	function hydrate(index) {
-		if (index === UNDEFINED) return undefined;
-		if (index === NAN) return NaN;
-		if (index === POSITIVE_INFINITY) return Infinity;
-		if (index === NEGATIVE_INFINITY) return -Infinity;
-		if (index === NEGATIVE_ZERO) return -0;
+		const constant = hydrateConstant(index);
+		if (constant !== NOT_A_CONSTANT) return constant;
 
 		if (index in hydrated) return hydrated[index];
 
@@ -104,4 +109,16 @@ export function parse(serialized) {
 	}
 
 	return hydrate(0);
+}
+
+const NOT_A_CONSTANT = Symbol('not a constant');
+
+/** @param {number} constant */
+function hydrateConstant(constant) {
+	if (constant === UNDEFINED) return undefined;
+	if (constant === NAN) return NaN;
+	if (constant === POSITIVE_INFINITY) return Infinity;
+	if (constant === NEGATIVE_INFINITY) return -Infinity;
+	if (constant === NEGATIVE_ZERO) return -0;
+	return NOT_A_CONSTANT;
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -17,7 +17,7 @@ export function parse(serialized) {
 	if (typeof parsed === 'number') return hydrate(parsed, true);
 
 	if (!Array.isArray(parsed) || parsed.length === 0) {
-		throw new SyntaxError('Invalid input');
+		throw new Error('Invalid input');
 	}
 
 	const values = /** @type {any[]} */ (parsed);
@@ -32,7 +32,7 @@ export function parse(serialized) {
 		if (index === NEGATIVE_INFINITY) return -Infinity;
 		if (index === NEGATIVE_ZERO) return -0;
 
-		if (standalone) throw new SyntaxError(`Invalid input`);
+		if (standalone) throw new Error(`Invalid input`);
 
 		if (index in hydrated) return hydrated[index];
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -16,14 +16,11 @@ export function parse(serialized) {
 
 	if (typeof parsed === 'number') return hydrate(parsed, true);
 
-	if (!Array.isArray(parsed)) {
-		throw new SyntaxError(
-			`Expected array, got ${parsed === null ? 'null' : typeof parsed}`
-		);
+	if (!Array.isArray(parsed) || parsed.length === 0) {
+		throw new SyntaxError('Invalid input');
 	}
 
 	const values = /** @type {any[]} */ (parsed);
-	if (values.length === 0) throw new SyntaxError(`Unexpected empty array`);
 
 	const hydrated = Array(values.length);
 
@@ -35,7 +32,7 @@ export function parse(serialized) {
 		if (index === NEGATIVE_INFINITY) return -Infinity;
 		if (index === NEGATIVE_ZERO) return -0;
 
-		if (standalone) throw new SyntaxError(`Unexpected number ${index}`);
+		if (standalone) throw new SyntaxError(`Invalid input`);
 
 		if (index in hydrated) return hydrated[index];
 

--- a/test/test.js
+++ b/test/test.js
@@ -442,7 +442,7 @@ for (const { name, json, message } of invalid) {
 	uvu.test(`parse error: ${name}`, () => {
 		assert.throws(
 			() => parse(json),
-			(error) => error instanceof SyntaxError && error.message === message
+			(error) => error.message === message
 		);
 	});
 }

--- a/test/test.js
+++ b/test/test.js
@@ -390,6 +390,55 @@ for (const [name, tests] of Object.entries(fixtures)) {
 	test.run();
 }
 
+const syntaxErrorFixtures = [
+	{
+		name: 'empty string',
+		json: ''
+	},
+	{
+		name: 'invalid JSON',
+		json: ']['
+	},
+	{
+		name: 'hole',
+		json: '-2'
+	},
+	{
+		name: 'string',
+		json: '"hello"',
+	},
+	{
+		name: 'number',
+		json: '42'
+	},
+	{
+		name: 'boolean',
+		json: 'true'
+	},
+	{
+		name: 'null',
+		json: 'null'
+	},
+	{
+		name: 'object',
+		json: '{}'
+	},
+	{
+		name: 'empty array',
+		json: '[]'
+	}
+];
+
+const syntaxErrorTest = uvu.suite("parse: syntax errors");
+
+for (const fixture of syntaxErrorFixtures) {
+	syntaxErrorTest(fixture.name, () => {
+		assert.throws(() => parse(fixture.json), (error) => error instanceof SyntaxError);
+	});
+}
+
+syntaxErrorTest.run();
+
 for (const fn of [uneval, stringify]) {
 	uvu.test(`${fn.name} throws for non-POJOs`, () => {
 		class Foo {}

--- a/test/test.js
+++ b/test/test.js
@@ -390,54 +390,62 @@ for (const [name, tests] of Object.entries(fixtures)) {
 	test.run();
 }
 
-const syntaxErrorFixtures = [
+const invalid = [
 	{
 		name: 'empty string',
-		json: ''
+		json: '',
+		message: 'Unexpected end of JSON input'
 	},
 	{
 		name: 'invalid JSON',
-		json: ']['
+		json: '][',
+		message: 'Unexpected token ] in JSON at position 0'
 	},
 	{
 		name: 'hole',
-		json: '-2'
+		json: '-2',
+		message: 'Unexpected number -2'
 	},
 	{
 		name: 'string',
 		json: '"hello"',
+		message: 'Expected array, got string'
 	},
 	{
 		name: 'number',
-		json: '42'
+		json: '42',
+		message: 'Unexpected number 42'
 	},
 	{
 		name: 'boolean',
-		json: 'true'
+		json: 'true',
+		message: 'Expected array, got boolean'
 	},
 	{
 		name: 'null',
-		json: 'null'
+		json: 'null',
+		message: 'Expected array, got null'
 	},
 	{
 		name: 'object',
-		json: '{}'
+		json: '{}',
+		message: 'Expected array, got object'
 	},
 	{
 		name: 'empty array',
-		json: '[]'
+		json: '[]',
+		message: 'Unexpected empty array'
 	}
 ];
 
-const syntaxErrorTest = uvu.suite("parse: syntax errors");
-
-for (const fixture of syntaxErrorFixtures) {
-	syntaxErrorTest(fixture.name, () => {
-		assert.throws(() => parse(fixture.json), (error) => error instanceof SyntaxError);
+for (const { name, json, message } of invalid) {
+	uvu.test(`parse error: ${name}`, () => {
+		assert.throws(
+			() => parse(json),
+			(error) => error instanceof SyntaxError && error.message === message
+		);
 	});
 }
-
-syntaxErrorTest.run();
 
 for (const fn of [uneval, stringify]) {
 	uvu.test(`${fn.name} throws for non-POJOs`, () => {

--- a/test/test.js
+++ b/test/test.js
@@ -404,37 +404,37 @@ const invalid = [
 	{
 		name: 'hole',
 		json: '-2',
-		message: 'Unexpected number -2'
+		message: 'Invalid input'
 	},
 	{
 		name: 'string',
 		json: '"hello"',
-		message: 'Expected array, got string'
+		message: 'Invalid input'
 	},
 	{
 		name: 'number',
 		json: '42',
-		message: 'Unexpected number 42'
+		message: 'Invalid input'
 	},
 	{
 		name: 'boolean',
 		json: 'true',
-		message: 'Expected array, got boolean'
+		message: 'Invalid input'
 	},
 	{
 		name: 'null',
 		json: 'null',
-		message: 'Expected array, got null'
+		message: 'Invalid input'
 	},
 	{
 		name: 'object',
 		json: '{}',
-		message: 'Expected array, got object'
+		message: 'Invalid input'
 	},
 	{
 		name: 'empty array',
 		json: '[]',
-		message: 'Unexpected empty array'
+		message: 'Invalid input'
 	}
 ];
 


### PR DESCRIPTION
At the moment, if `parse` encounters valid JSON in an unexpected format, it may either throw a confusing error, or silently return the wrong output.

```js
parse('"hello"') // => 'h'
parse('42') // =>  ReferenceError: Cannot access 'hydrated' before initialization
parse('true') // => undefined
parse('null') // => TypeError: Cannot read properties of null (reading 'length')
parse('{}') // => undefined
parse('[]') // => undefined
```

This PR introduces checks for unexpected values before hydrating and throws a `SyntaxError` if the input cannot be parsed.