### PR TITLE
only deduplicate non-primitives

### DIFF
--- a/src/uneval.js
+++ b/src/uneval.js
@@ -30,14 +30,14 @@ export function uneval(value) {
 			throw new DevalueError(`Cannot stringify a function`, keys);
 		}
 
-		if (counts.has(thing)) {
-			counts.set(thing, counts.get(thing) + 1);
-			return;
-		}
-
-		counts.set(thing, 1);
-
 		if (!is_primitive(thing)) {
+			if (counts.has(thing)) {
+				counts.set(thing, counts.get(thing) + 1);
+				return;
+			}
+
+			counts.set(thing, 1);
+
 			const type = get_type(thing);
 
 			switch (type) {

--- a/test/test.js
+++ b/test/test.js
@@ -299,9 +299,25 @@ const fixtures = {
 		{
 			name: 'String (repetition)',
 			value: ['a string', 'a string'],
-			js: '(function(a){return [a,a]}("a string"))',
+			js: '["a string","a string"]',
 			json: '[[1,1],"a string"]'
-		}
+		},
+
+		{
+			name: 'null (repetition)',
+			value: [null, null],
+			js: '[null,null]',
+			json: '[[1,1],null]'
+		},
+
+		((object) => {
+			return {
+				name: 'Object (repetition)',
+				value: [object, object],
+				js: '(function(a){return [a,a]}({}))',
+				json: '[[1,1],{}]'
+			};
+		})({})
 	],
 
 	XSS: [


### PR DESCRIPTION
Currently, all values are deduplicated, meaning that input like `[null, null]` will result in this output:

```js
(function(a){return [a,a]}(null))
```

In very simple cases like the one above, this creates overhead. In very complex cases, it can result in an IIFE with too many function arguments (https://github.com/sveltejs/kit/issues/6672). With this change, it would still be _possible_ to reach that threshold, but it's far less likely.

In some cases this will result in larger payloads, but gzip/brotli compression will take care of it in all the places that it matters.