### PR TITLE
export `DevalueError`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 export { uneval } from './src/uneval.js';
 export { parse, unflatten } from './src/parse.js';
 export { stringify } from './src/stringify.js';
+export { DevalueError } from './src/utils.js';

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 import * as vm from 'vm';
 import * as assert from 'uvu/assert';
 import * as uvu from 'uvu';
-import { uneval, unflatten, parse, stringify } from '../index.js';
+import { uneval, unflatten, parse, stringify, DevalueError } from '../index.js';
 
 const fixtures = {
 	basics: [
@@ -525,6 +525,10 @@ uvu.test('does not create duplicate parameter names', () => {
 	const serialized = uneval([foo, ...bar]);
 
 	eval(serialized);
+});
+
+uvu.test('DevalueError is exported', () => {
+        assert.ok(DevalueError);
 });
 
 uvu.test.run();


### PR DESCRIPTION
This PR exports `DevalueError`.

Access to the error class is useful for type narrowing when access to `DevalueError`'s `path` property is needed. Also helpful if other errors might be thrown in the same scope.

```typescript
import * devalue from "devalue";

const foo = () => void 0;

try {
  devalue.stringify(foo);
} catch (error) {
  if (error instanceof devalue.DevalueError) {
    error.path; // typed
  }
}
```

I added a dumb test just to check the presence of the export. I can remove it if you think it's unnecessary.

Thanks!
