### PR TITLE
add x1D group separator to escaped

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,8 @@ export const escaped = {
 	'\t': '\\t',
 	'\0': '\\u0000',
 	'\u2028': '\\u2028',
-	'\u2029': '\\u2029'
+	'\u2029': '\\u2029',
+	'\x1D': '\\u001d'
 };
 
 export class DevalueError extends Error {

--- a/test/test.js
+++ b/test/test.js
@@ -205,6 +205,12 @@ const fixtures = {
 			value: '\\',
 			js: JSON.stringify('\\'),
 			json: '["\\\\"]'
+		},
+		{
+			name: 'group separator',
+			value: '\x1D',
+			js: JSON.stringify('\x1D'),
+			json: '["\\u001d"]'
 		}
 	],
 


### PR DESCRIPTION
So I noticed an error in SvelteKit load functions that were happening on page transitions (so the data is getting passed through `devalue`) when the data included a string coming from GitHub's API.

The string in question was a long string of markdown, but the pertinent bit was a line like `- \x1DFix CSS handling`

Lord knows why the `\x1D` sequence is in there, but it is.

When that goes through devalue.stringify, that sequence ends up in the string as the raw [`Group separator` character](https://condor.depaul.edu/sjost/lsp121/documents/ascii-npr.htm), which both JSON.parse and devalue.parse then choke on if you have to parse that string.

I've got [a JSFiddle with a minimal reproduction here](https://jsfiddle.net/4xm6vnty/4/)

If you run that bit through JSON.stringify, that `\x1D` sequence gets escaped to `\\u001d`, so it seems like if we extended the [list of characters to escape](https://github.com/Rich-Harris/devalue/blob/master/src/utils.js#L1-L15) that might cover it? 

Monkey patching `escaped` in a local install with `'\x1D': '\\u001d'` got things rolling again.

Seemed easy enough to do, so voila. Unless you think this is a bad idea?