### PR TITLE
feat: add support to the Decimal object

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -73,6 +73,7 @@ export function stringify(value, reducers) {
 				case 'Number':
 				case 'String':
 				case 'Boolean':
+				case 'Decimal':
 					str = `["Object",${stringify_primitive(thing)}]`;
 					break;
 

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -57,6 +57,7 @@ export function uneval(value, replacer) {
 				case 'Boolean':
 				case 'Date':
 				case 'RegExp':
+				case 'Decimal':
 					return;
 
 				case 'Array':
@@ -206,6 +207,7 @@ export function uneval(value, replacer) {
 				case 'Number':
 				case 'String':
 				case 'Boolean':
+				case 'Decimal':
 					values.push(`Object(${stringify(thing.valueOf())})`);
 					break;
 


### PR DESCRIPTION
This adds support to the `Decimal` object from [decimal.js](https://mikemcl.github.io/decimal.js/). This is needed when running `uneval` on a Prisma payload with the Decimal "type".

## Use case
- Use `devalue` as a `TRPC` transformer
- Use Prisma as your ORM and have a [Decimal object](https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields#working-with-decimal) column
