### PR TITLE
perf: speed up stringify_string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "devalue",
+	"name": "devalue2",
 	"description": "Gets the job done when JSON.stringify can't",
 	"version": "4.3.0",
 	"repository": "Rich-Harris/devalue",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "devalue2",
+	"name": "devalue",
 	"description": "Gets the job done when JSON.stringify can't",
 	"version": "4.3.0",
 	"repository": "Rich-Harris/devalue",

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -8,7 +8,7 @@ import {
 } from './utils.js';
 
 const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$';
-const unsafe_chars = /[<>\b\f\n\r\t\0\u2028\u2029]/g;
+const unsafe_chars = /[<\b\f\n\r\t\0\u2028\u2029]/g;
 const reserved =
 	/^(?:do|if|in|for|int|let|new|try|var|byte|case|char|else|enum|goto|long|this|void|with|await|break|catch|class|const|final|float|short|super|throw|while|yield|delete|double|export|import|native|return|switch|throws|typeof|boolean|default|extends|finally|package|private|abstract|continue|debugger|function|volatile|interface|protected|transient|implements|instanceof|synchronized)$/;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,9 @@ export function is_primitive(thing) {
 	return Object(thing) !== thing;
 }
 
-const object_proto_names = /* @__PURE__ */ Object.getOwnPropertyNames(Object.prototype)
+const object_proto_names = /* @__PURE__ */ Object.getOwnPropertyNames(
+	Object.prototype
+)
 	.sort()
 	.join('\0');
 
@@ -93,7 +95,5 @@ export function stringify_string(str) {
 		}
 	}
 
-	result += str.slice(last_pos);
-
-	return `"${result}"`;
+	return `"${last_pos === 0 ? str : result + str.slice(last_pos)}"`;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,12 @@
 /** @type {Record<string, string>} */
 export const escaped = {
 	'<': '\\u003C',
-	'>': '\\u003E',
-	'/': '\\u002F',
 	'\\': '\\\\',
 	'\b': '\\b',
 	'\f': '\\f',
 	'\n': '\\n',
 	'\r': '\\r',
 	'\t': '\\t',
-	'\0': '\\u0000',
 	'\u2028': '\\u2028',
 	'\u2029': '\\u2029'
 };
@@ -31,7 +28,7 @@ export function is_primitive(thing) {
 	return Object(thing) !== thing;
 }
 
-const object_proto_names = Object.getOwnPropertyNames(Object.prototype)
+const object_proto_names = /* @__PURE__ */ Object.getOwnPropertyNames(Object.prototype)
 	.sort()
 	.join('\0');
 
@@ -51,35 +48,52 @@ export function get_type(thing) {
 	return Object.prototype.toString.call(thing).slice(8, -1);
 }
 
+/** @param {string} char */
+function get_escaped_char(char) {
+	switch (char) {
+		case '"':
+			return '\\"';
+		case '<':
+			return '\\u003C';
+		case '\\':
+			return '\\\\';
+		case '\n':
+			return '\\n';
+		case '\r':
+			return '\\r';
+		case '\t':
+			return '\\t';
+		case '\b':
+			return '\\b';
+		case '\f':
+			return '\\f';
+		case '\u2028':
+			return '\\u2028';
+		case '\u2029':
+			return '\\u2029';
+		default:
+			return char < ' '
+				? `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`
+				: '';
+	}
+}
+
 /** @param {string} str */
 export function stringify_string(str) {
-	let result = '"';
+	let result = '';
+	let last_pos = 0;
+	const len = str.length;
 
-	for (let i = 0; i < str.length; i += 1) {
-		const char = str.charAt(i);
-		const code = char.charCodeAt(0);
-
-		if (char === '"') {
-			result += '\\"';
-		} else if (char in escaped) {
-			result += escaped[char];
-		} else if (code <= 0x001F) {
-			result += `\\u${code.toString(16).toUpperCase().padStart(4, "0")}`
-		} else if (code >= 0xd800 && code <= 0xdfff) {
-			const next = str.charCodeAt(i + 1);
-
-			// If this is the beginning of a [high, low] surrogate pair,
-			// add the next two characters, otherwise escape
-			if (code <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
-				result += char + str[++i];
-			} else {
-				result += `\\u${code.toString(16).toUpperCase()}`;
-			}
-		} else {
-			result += char;
+	for (let i = 0; i < len; i += 1) {
+		const char = str[i];
+		const replacement = get_escaped_char(char);
+		if (replacement) {
+			result += str.slice(last_pos, i) + replacement;
+			last_pos = i + 1;
 		}
 	}
 
-	result += '"';
-	return result;
+	result += str.slice(last_pos);
+
+	return `"${result}"`;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -167,26 +167,26 @@ const fixtures = {
 		{
 			name: 'lone low surrogate',
 			value: 'a\uDC00b',
-			js: '"a\\uDC00b"',
-			json: '["a\\uDC00b"]'
+			js: '"a\uDC00b"',
+			json: '["a\uDC00b"]'
 		},
 		{
 			name: 'lone high surrogate',
 			value: 'a\uD800b',
-			js: '"a\\uD800b"',
-			json: '["a\\uD800b"]'
+			js: '"a\uD800b"',
+			json: '["a\uD800b"]'
 		},
 		{
 			name: 'two low surrogates',
 			value: 'a\uDC00\uDC00b',
-			js: '"a\\uDC00\\uDC00b"',
-			json: '["a\\uDC00\\uDC00b"]'
+			js: '"a\uDC00\uDC00b"',
+			json: '["a\uDC00\uDC00b"]'
 		},
 		{
 			name: 'two high surrogates',
 			value: 'a\uD800\uD800b',
-			js: '"a\\uD800\\uD800b"',
-			json: '["a\\uD800\\uD800b"]'
+			js: '"a\uD800\uD800b"',
+			json: '["a\uD800\uD800b"]'
 		},
 		{
 			name: 'surrogate pair',
@@ -197,8 +197,8 @@ const fixtures = {
 		{
 			name: 'surrogate pair in wrong order',
 			value: 'a\uDC00\uD800b',
-			js: '"a\\uDC00\\uD800b"',
-			json: '["a\\uDC00\\uD800b"]'
+			js: '"a\uDC00\uD800b"',
+			json: '["a\uDC00\uD800b"]'
 		},
 		{
 			name: 'nul',
@@ -215,8 +215,8 @@ const fixtures = {
 		{
 			name: 'control character extremum',
 			value: '\u001F',
-			js: '"\\u001F"',
-			json: '["\\u001F"]'
+			js: '"\\u001f"',
+			json: '["\\u001f"]'
 		},
 		{
 			name: 'backslash',
@@ -342,20 +342,20 @@ const fixtures = {
 		{
 			name: 'Dangerous string',
 			value: `</script><script src='https://evil.com/script.js'>alert('pwned')</script><script>`,
-			js: `"\\u003C\\u002Fscript\\u003E\\u003Cscript src='https:\\u002F\\u002Fevil.com\\u002Fscript.js'\\u003Ealert('pwned')\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003E"`,
-			json: `["\\u003C\\u002Fscript\\u003E\\u003Cscript src='https:\\u002F\\u002Fevil.com\\u002Fscript.js'\\u003Ealert('pwned')\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003E"]`
+			js: `"\\u003C/script>\\u003Cscript src='https://evil.com/script.js'>alert('pwned')\\u003C/script>\\u003Cscript>"`,
+			json: `["\\u003C/script>\\u003Cscript src='https://evil.com/script.js'>alert('pwned')\\u003C/script>\\u003Cscript>"]`
 		},
 		{
 			name: 'Dangerous key',
 			value: { '<svg onload=alert("xss_works")>': 'bar' },
-			js: '{"\\u003Csvg onload=alert(\\"xss_works\\")\\u003E":"bar"}',
-			json: '[{"\\u003Csvg onload=alert(\\"xss_works\\")\\u003E":1},"bar"]'
+			js: '{"\\u003Csvg onload=alert(\\"xss_works\\")>":"bar"}',
+			json: '[{"\\u003Csvg onload=alert(\\"xss_works\\")>":1},"bar"]'
 		},
 		{
 			name: 'Dangerous regex',
 			value: /[</script><script>alert('xss')//]/,
-			js: `new RegExp("[\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003Ealert('xss')\\u002F\\u002F]", "")`,
-			json: `[["RegExp","[\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003Ealert('xss')\\u002F\\u002F]"]]`
+			js: `new RegExp("[\\u003C/script>\\u003Cscript>alert('xss')//]", "")`,
+			json: `[["RegExp","[\\u003C/script>\\u003Cscript>alert('xss')//]"]]`
 		}
 	],
 


### PR DESCRIPTION
> A string is a sequence of Unicode code points wrapped with quotation marks (U+0022). All code points may be placed within the quotation marks except for the code points that must be escaped: quotation mark (U+0022), reverse solidus (U+005C), and the control characters U+0000 to U+001F.

According to the JSON spec, anything except "\ and the control characters can go in the string, the only characters we want to escape in addition would be `<`, `\u2028` and `\u2029` for HTML embedding (unless I'm missing something).

Instead of building up strings character by, 
1. this adds a fast path for just returning the original string wrapped by quotes if there are no characters to be escaped
2. If there are any to be escaped, it'll copy chunks of the string at once

and the object key hashmap key seems to be 25% ish slower than the switch version, this does introduce some duplication but it should only be on the server side, will try to consolidate both at some point.

Results:
```
Running "circular-dedupe to string" suite...
    97 562 ops/s, ±0.54%    | slowest, 39.26% slower
    160 633 ops/s, ±0.13%   | fastest
Running "circular-simple to string" suite...
    401 480 ops/s, ±0.22%   | slowest, 36.8% slower
    635 267 ops/s, ±0.17%   | fastest
Running "dedupe-object to string" suite...
    194 025 ops/s, ±0.28%   | slowest, 39.8% slower
    322 282 ops/s, ±0.12%   | fastest
Running "large-circular-collection to string" suite...
    571 ops/s, ±0.37%     | slowest, 54.32% slower
    1 250 ops/s, ±0.38%   | fastest
Running "large-complex-collection to string" suite...
    2 481 ops/s, ±0.19%   | slowest, 64.81% slower
    7 050 ops/s, ±0.11%   | fastest
Running "large-dedupe-collection to string" suite...
    611 ops/s, ±0.43%     | slowest, 52.49% slower
    1 286 ops/s, ±0.18%   | fastest
Running "large-invalid-keys-collection to string" suite...
    169 ops/s, ±0.41%   | slowest, 51.85% slower
    351 ops/s, ±2.11%   | fastest
Running "large-simple-collection to string" suite...
    160 ops/s, ±0.98%   | slowest, 53.35% slower
    343 ops/s, ±0.61%   | fastest
Running "simple-object to string" suite...
    826 857 ops/s, ±0.55%     | slowest, 27.49% slower
    1 140 336 ops/s, ±0.24%   | fastest
Running "small-collection to string" suite...
    59 066 ops/s, ±0.23%    | slowest, 54.59% slower
    130 076 ops/s, ±0.30%   | fastest
```

I modified the [seroval benchmark](https://github.com/lxsmnsyc/seroval/tree/main/benchmark) to compare stringify/parse results instead of uneval/eval and sprinkled in some control characters in some of the strings. The first line in each is the previous version, and the second line is with this PR.