### PR TITLE
Add support for async revivers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 export { uneval } from './src/uneval.js';
-export { parse, unflatten } from './src/parse.js';
+export { parse, unflatten, parseAsync, unflattenAsync } from './src/parse.js';
 export { stringify } from './src/stringify.js';

--- a/src/parse.js
+++ b/src/parse.js
@@ -131,3 +131,128 @@ export function unflatten(parsed, revivers) {
 
 	return hydrate(0);
 }
+
+/**
+ * Revive a value serialized with `devalue.stringify` asynchronously
+ * @param { string } serialized
+ * @param {Record<string, (value: any) => Promise<any>>} [revivers]
+ */
+export async function parseAsync(serialized, revivers) {
+	return await unflattenAsync(JSON.parse(serialized), revivers);
+}
+
+/**
+ * Revive a value flattened with `devalue.stringify` asynchronously
+ * @param {number | any[]} parsed
+ * @param {Record<string, (value: any) => Promise<any>>} [revivers]
+ */
+export async function unflattenAsync(parsed, revivers) {
+	if (typeof parsed === 'number') return await hydrate(parsed, true);
+
+	if (!Array.isArray(parsed) || parsed.length === 0) {
+		throw new Error('Invalid input');
+	}
+
+	const values = /** @type {any[]} */ (parsed);
+
+	const hydrated = Array(values.length);
+
+	/**
+	 * @param {number} index
+	 * @returns {Promise<any>}
+	 */
+	async function hydrate(index, standalone = false) {
+		if (index === UNDEFINED) return undefined;
+		if (index === NAN) return NaN;
+		if (index === POSITIVE_INFINITY) return Infinity;
+		if (index === NEGATIVE_INFINITY) return -Infinity;
+		if (index === NEGATIVE_ZERO) return -0;
+
+		if (standalone) throw new Error(`Invalid input`);
+
+		if (index in hydrated) return hydrated[index];
+
+		const value = values[index];
+
+		if (!value || typeof value !== 'object') {
+			hydrated[index] = value;
+		} else if (Array.isArray(value)) {
+			if (typeof value[0] === 'string') {
+				const type = value[0];
+
+				const reviver = revivers?.[type];
+				if (reviver) {
+					return (hydrated[index] = await reviver(await hydrate(value[1])));
+				}
+
+				switch (type) {
+					case 'Date':
+						hydrated[index] = new Date(value[1]);
+						break;
+
+					case 'Set':
+						const set = new Set();
+						hydrated[index] = set;
+						for (let i = 1; i < value.length; i += 1) {
+							set.add(await hydrate(value[i]));
+						}
+						break;
+
+					case 'Map':
+						const map = new Map();
+						hydrated[index] = map;
+						for (let i = 1; i < value.length; i += 2) {
+							map.set(await hydrate(value[i]), await hydrate(value[i + 1]));
+						}
+						break;
+
+					case 'RegExp':
+						hydrated[index] = new RegExp(value[1], value[2]);
+						break;
+
+					case 'Object':
+						hydrated[index] = Object(value[1]);
+						break;
+
+					case 'BigInt':
+						hydrated[index] = BigInt(value[1]);
+						break;
+
+					case 'null':
+						const obj = Object.create(null);
+						hydrated[index] = obj;
+						for (let i = 1; i < value.length; i += 2) {
+							obj[value[i]] = await hydrate(value[i + 1]);
+						}
+						break;
+
+					default:
+						throw new Error(`Unknown type ${type}`);
+				}
+			} else {
+				const array = new Array(value.length);
+				hydrated[index] = array;
+
+				for (let i = 0; i < value.length; i += 1) {
+					const n = value[i];
+					if (n === HOLE) continue;
+
+					array[i] = await hydrate(n);
+				}
+			}
+		} else {
+			/** @type {Record<string, any>} */
+			const object = {};
+			hydrated[index] = object;
+
+			for (const key in value) {
+				const n = value[key];
+				object[key] = await hydrate(n);
+			}
+		}
+
+		return hydrated[index];
+	}
+
+	return await hydrate(0);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 import * as vm from 'vm';
 import * as assert from 'uvu/assert';
 import * as uvu from 'uvu';
-import { uneval, unflatten, parse, stringify } from '../index.js';
+import { uneval, unflatten, parse, stringify, unflattenAsync, parseAsync } from '../index.js';
 
 class Custom {
 	constructor(value) {
@@ -399,6 +399,9 @@ const fixtures = {
 			revivers: {
 				Custom: (x) => new Custom(x)
 			},
+			asyncRevivers: {
+				Custom: async (x) => new Custom(x)
+			},
 			validate: ([obj1, obj2]) => {
 				assert.is(obj1, obj2);
 				assert.ok(obj1 instanceof Custom);
@@ -445,6 +448,16 @@ for (const [name, tests] of Object.entries(fixtures)) {
 				assert.equal(actual, expected);
 			}
 		});
+		test(`${t.name} (async)`, async () => {
+			const actual = await parseAsync(t.json, t.asyncRevivers);
+			const expected = t.value;
+
+			if (t.validate) {
+				t.validate(actual);
+			} else {
+				assert.equal(actual, expected);
+			}
+		});
 	}
 	test.run();
 }
@@ -454,6 +467,16 @@ for (const [name, tests] of Object.entries(fixtures)) {
 	for (const t of tests) {
 		test(t.name, () => {
 			const actual = unflatten(JSON.parse(t.json), t.revivers);
+			const expected = t.value;
+
+			if (t.validate) {
+				t.validate(actual);
+			} else {
+				assert.equal(actual, expected);
+			}
+		});
+		test(`${t.name} (async)`, async () => {
+			const actual = await unflattenAsync(JSON.parse(t.json), t.asyncRevivers);
 			const expected = t.value;
 
 			if (t.validate) {
@@ -514,12 +537,25 @@ const invalid = [
 	}
 ];
 
+// SYNC
 for (const { name, json, message } of invalid) {
 	uvu.test(`parse error: ${name}`, () => {
 		assert.throws(
 			() => parse(json),
 			(error) => error.message === message
 		);
+	});
+}
+// ASYNC
+for (const { name, json, message } of invalid) {
+	uvu.test(`parseAsync error: ${name}`, async () => {
+		try {
+			await parseAsync(json);
+			assert.unreachable('Expected parseAsync to throw')
+		}
+		catch (error) {
+			assert.equal(error.message, message);
+		}
 	});
 }
 


### PR DESCRIPTION
I wanted to use dynamic imports in revivers to make them more generic. However, the current implementation doesn't allow this because the parsed value would be a promise.
This PR introduces asynchronous versions of `unflatten` and `parse`, enabling this functionality. I updated the tests accordingly.

Initially, I considered extracting parts of the hydrate function into separate functions for reuse in the async version, however, after some thinking I decided against it due to potential performance issues. I think it's best if we call as few functions as possible here - since it's a recursive call chain.