### PR TITLE
fix: do not iterate over prototype properties of reducers

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -31,8 +31,10 @@ export function stringify(value, reducers) {
 
 	/** @type {Array<{ key: string, fn: (value: any) => any }>} */
 	const custom = [];
-	for (const key of Object.getOwnPropertyNames(reducers)) {
-		custom.push({ key, fn: reducers[key] });
+	if (reducers) {
+		for (const key of Object.getOwnPropertyNames(reducers)) {
+			custom.push({ key, fn: reducers[key] });
+		}
 	}
 
 	/** @type {string[]} */

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -29,7 +29,7 @@ export function stringify(value, reducers) {
 
 	/** @type {Array<{ key: string, fn: (value: any) => any }>} */
 	const custom = [];
-	for (const key in reducers) {
+	for (const key of Object.getOwnPropertyNames(reducers)) {
 		custom.push({ key, fn: reducers[key] });
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -167,7 +167,7 @@ const fixtures = {
 			json: '[["Uint8Array","AQID"]]'
 		},
 		{
-			name: "ArrayBuffer",
+			name: 'ArrayBuffer',
 			value: new Uint8Array([1, 2, 3]).buffer,
 			js: 'new Uint8Array([1,2,3]).buffer',
 			json: '[["ArrayBuffer","AQID"]]'
@@ -429,9 +429,10 @@ const fixtures = {
 					return `new Custom(${uneval(value.value)})`;
 				}
 			},
-			reducers: {
+			// test for https://github.com/Rich-Harris/devalue/pull/80
+			reducers: Object.assign(Object.create({ polluted: true }), {
 				Custom: (x) => x instanceof Custom && x.value
-			},
+			}),
 			revivers: {
 				Custom: (x) => new Custom(x)
 			},


### PR DESCRIPTION
reproduction: https://stackblitz.com/edit/stackblitz-starters-iiewc5

```ts
import { stringify } from 'devalue';

let a = {};
a.__proto__.appConfigEnabled = 1;

stringify({}, {});
// Error: fn is not a function
```