### PR TITLE
chore: marked package as free of side-effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"description": "Gets the job done when JSON.stringify can't",
 	"version": "5.0.0",
 	"repository": "Rich-Harris/devalue",
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"types": "./types/index.d.ts",


### PR DESCRIPTION
Hey!

I noticed a bare import to devalue in svelte-kit SSR output: (.svelte-kit/output/server/chunks/client.js)

```js
import "./exports.js";
import "devalue";
function get(key, parse = JSON.parse) {
  try {
    return parse(sessionStorage[key]);
  } catch {
  }
}
const SNAPSHOT_KEY = "sveltekit:snapshot";
const SCROLL_KEY = "sveltekit:scroll";
get(SCROLL_KEY) ?? {};
get(SNAPSHOT_KEY) ?? {};
```

This directive will ensure that this bare import is removed during the build