### PR TITLE
feat: allow function type reducers and revivers

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -442,12 +442,36 @@ const fixtures = {
 				assert.equal(obj1.value.answer, 42);
 			}
 		}
-	])(new Custom({ answer: 42 }))
+	])(new Custom({ answer: 42 })),
+
+	customFunction: ((func) => [
+		{
+			name: 'Custom function type',
+			value: func,
+			json: '[["function",1],"func"]',
+			reducers: {
+				function: (x) => x === func && 'func'
+			},
+			revivers: {
+        function: (x) => {
+          assert.is(x, 'func');
+          return func;
+        }
+			},
+			validate: (f) => {
+				assert.is(f, func);
+			}
+		}
+	])(() => 42)
 };
 
 for (const [name, tests] of Object.entries(fixtures)) {
 	const test = uvu.suite(`uneval: ${name}`);
 	for (const t of tests) {
+    if (!t.js) {
+      continue;
+    }
+
 		test(t.name, () => {
 			const actual = uneval(t.value, t.replacer);
 			const expected = t.js;


### PR DESCRIPTION
This also technically just allows any type to be overridden with reducers and revivers. I think this fixes #71.

My use-case is I want to update https://github.com/markwylde/workerbox to use `devalue` for passing values between the worker the UI thread, but I need to set a custom reducer and reviver for functions, which `devalue` doesn't currently let me do.