### PR TITLE
fix stringify not picking up negative zero if a normal zero has appeared before it

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -48,13 +48,13 @@ export function stringify(value, reducers) {
 			throw new DevalueError(`Cannot stringify a function`, keys);
 		}
 
-		if (indexes.has(thing)) return indexes.get(thing);
-
 		if (thing === undefined) return UNDEFINED;
 		if (Number.isNaN(thing)) return NAN;
 		if (thing === Infinity) return POSITIVE_INFINITY;
 		if (thing === -Infinity) return NEGATIVE_INFINITY;
 		if (thing === 0 && 1 / thing < 0) return NEGATIVE_ZERO;
+
+		if (indexes.has(thing)) return indexes.get(thing);
 
 		const index = p++;
 		indexes.set(thing, index);

--- a/test/test.js
+++ b/test/test.js
@@ -125,6 +125,12 @@ const fixtures = {
 			json: '[[1,2,3],"a","b","c"]'
 		},
 		{
+			name: 'Array where negative zero appears after normal zero',
+			value: [0, -0],
+			js: '[0,-0]',
+			json: '[[1,-6],0]'
+		},
+		{
 			name: 'Array (empty)',
 			value: [],
 			js: '[]',


### PR DESCRIPTION
I found this while I was messing around with this package after I started doing some sveltekit prototyping. Just run the test I added in this PR without the included fix and notice how it stringifies it to just a normal zero.

I think the reason this fails is because `indexes.has(thing)` will return true if `thing` is negative zero and `indexes` contains a value for normal zero.

So my proposed fix is fairly simple: just first check for all the constants before checking the indexes map. Now I do not know if this has any unintended side-effects. So if I overlooked something feel free to deny this PR and cook up something else 😛.

Now while I dont really need correct support for negative zero myself, since the readme explicitly mentions support for it, I figured might as well PR it 😄.