### PR TITLE
POC: allow stringifying/parsing async values

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -1,0 +1,137 @@
+import { stringify } from "./stringify.js";
+
+/**
+ * Checks if a value is a Promise-like object
+ * @param {unknown} value The value to check
+ * @returns {value is Promise<unknown>} True if the value is a Promise-like object, false otherwise
+ */
+function isPromise(value) {
+	return typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function';
+}
+
+const PROMISE_STATUS_FULFILLED = 0;
+const PROMISE_STATUS_REJECTED = 1;
+
+/**
+ * Streams a value into a JSON string that can be parsed with `devalue.parse`
+ * @param {unknown} value The value to stream
+ * @param {Record<string, (value: any) => any>} [revivers] Optional revivers to handle custom types
+ * @returns {AsyncGenerator<unknown>} An async generator that yields the streamed value
+ */
+export async function* stringifyStream(value, revivers = {}) {
+	let counter = 0;
+
+	/** @type {Set<{iterator: AsyncIterator<unknown>, nextPromise: Promise<IteratorResult<unknown, unknown>>}>} */
+	const buffer = new Set();
+
+	/**
+	 * Registers an async iterable callback and returns its index
+	 * @param {(idx: number) => AsyncIterable<unknown>} callback The async iterable callback function
+	 * @returns {number} The index assigned to this callback
+	 */
+	function registerAsyncIterable(callback) {
+		const idx = counter++;
+
+		const iterator = callback(idx)[Symbol.asyncIterator]();
+
+		const nextPromise = iterator.next();
+
+		nextPromise.catch(() => {
+			// prevent unhandled promise rejection
+		});
+		buffer.add({
+			iterator,
+			nextPromise,
+		});
+
+		return idx;
+	}
+
+	/**
+	 * Recursively stringifies a value, handling promises specially
+	 * @param {unknown} v The value to stringify
+	 * @returns {string} The stringified value
+	 */
+	function recurse(v) {
+		return stringify(v, {
+			...revivers,
+			Promise: (v) => {
+				if (!isPromise(v)) {
+					return false;
+				}
+				return [registerAsyncIterable(async function* () {
+					// console.log('registerAsyncIterable', v);
+					v.catch(() => {
+						// prevent unhandled promise rejection
+					});
+					try {
+						const next = await v;
+						return [PROMISE_STATUS_FULFILLED, next];
+					} catch (e) {
+						return [PROMISE_STATUS_REJECTED, e];
+					}
+				})]
+			},
+		});
+	}
+	try {
+		yield recurse(value);
+
+
+		while (buffer.size) {
+			// Race all iterators to get the next value from any of them
+			const [entry, res] = await Promise.race(
+				Array.from(buffer).map(async (it) => 
+					/** @type {const} */ ([it, await it.nextPromise]),
+				),
+			);
+
+			yield recurse(res.value);
+
+
+			// Remove current iterator and re-add if not done
+			buffer.delete(entry);
+			if (!res.done) {
+				entry.nextPromise = entry.iterator.next();
+				buffer.add(entry);
+			}
+		}
+
+	} finally {
+		// Return all iterators
+		await Promise.allSettled(Array.from(buffer).map(it => it.iterator.return()));
+	}
+}
+
+
+export function parseStream() {
+    
+}
+
+/**
+ * Creates a ReadableStream from an AsyncIterable.
+ * 
+ * @param {AsyncIterable<unknown>} iterable The source AsyncIterable to stream from
+ * @returns {ReadableStream} A ReadableStream that yields values from the AsyncIterable
+ */
+export function readableStreamFrom(iterable) {
+	const iterator = iterable[Symbol.asyncIterator]();
+
+	return new ReadableStream({
+		async cancel() {
+			await iterator.return?.();
+		},
+
+		async pull(controller) {
+			const result = await iterator.next();
+
+			if (result.done) {
+				controller.close();
+				return;
+			}
+
+			controller.enqueue(result.value);
+		},
+	});
+}
+  

--- a/src/async.js
+++ b/src/async.js
@@ -1,3 +1,4 @@
+import { parse } from "./parse.js";
 import { stringify } from "./stringify.js";
 
 /**
@@ -6,132 +7,271 @@ import { stringify } from "./stringify.js";
  * @returns {value is Promise<unknown>} True if the value is a Promise-like object, false otherwise
  */
 function isPromise(value) {
-	return typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function';
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
+}
+
+/**
+ * Checks if a value is an AsyncIterable object
+ * @param {unknown} value The value to check
+ * @returns {value is AsyncIterable<unknown>} True if the value is an AsyncIterable, false otherwise
+ */
+function isAsyncIterable(value) {
+  return (
+    typeof value === "object" && value !== null && Symbol.asyncIterator in value
+  );
 }
 
 const PROMISE_STATUS_FULFILLED = 0;
 const PROMISE_STATUS_REJECTED = 1;
 
+const ASYNC_ITERABLE_STATUS_YIELD = 0;
+const ASYNC_ITERABLE_STATUS_RETURN = 1;
+const ASYNC_ITERABLE_STATUS_ERROR = 2;
+
 /**
  * Streams a value into a JSON string that can be parsed with `devalue.parse`
  * @param {unknown} value The value to stream
  * @param {Record<string, (value: any) => any>} [revivers] Optional revivers to handle custom types
- * @returns {AsyncGenerator<unknown>} An async generator that yields the streamed value
+ * @returns {AsyncIterable<unknown>} An async iterable that yields the streamed value
  */
-export async function* stringifyStream(value, revivers = {}) {
-	let counter = 0;
+export async function* stringifyAsyncIterable(value, revivers = {}) {
+  let counter = 0;
 
-	/** @type {Set<{iterator: AsyncIterator<unknown>, nextPromise: Promise<IteratorResult<unknown, unknown>>}>} */
-	const buffer = new Set();
+  /** @type {Set<{iterator: AsyncIterator<unknown>, nextPromise: Promise<IteratorResult<unknown, unknown>>}>} */
+  const buffer = new Set();
 
-	/**
-	 * Registers an async iterable callback and returns its index
-	 * @param {(idx: number) => AsyncIterable<unknown>} callback The async iterable callback function
-	 * @returns {number} The index assigned to this callback
-	 */
-	function registerAsyncIterable(callback) {
-		const idx = counter++;
+  /**
+   * Registers an async iterable callback and returns its index
+   * @param {(idx: number) => AsyncIterable<`${string}:${string}:${string}`>} callback The async iterable callback function
+   * @returns {number} The index assigned to this callback
+   */
+  function registerAsyncIterable(callback) {
+    const idx = counter++;
 
-		const iterator = callback(idx)[Symbol.asyncIterator]();
+    const iterator = callback(idx)[Symbol.asyncIterator]();
 
-		const nextPromise = iterator.next();
+    const nextPromise = iterator.next();
 
-		nextPromise.catch(() => {
-			// prevent unhandled promise rejection
-		});
-		buffer.add({
-			iterator,
-			nextPromise,
-		});
+    nextPromise.catch(() => {
+      // prevent unhandled promise rejection
+    });
+    buffer.add({
+      iterator,
+      nextPromise,
+    });
 
-		return idx;
-	}
+    return idx;
+  }
 
-	/**
-	 * Recursively stringifies a value, handling promises specially
-	 * @param {unknown} v The value to stringify
-	 * @returns {string} The stringified value
-	 */
-	function recurse(v) {
-		return stringify(v, {
-			...revivers,
-			Promise: (v) => {
-				if (!isPromise(v)) {
-					return false;
-				}
-				return [registerAsyncIterable(async function* () {
-					// console.log('registerAsyncIterable', v);
-					v.catch(() => {
-						// prevent unhandled promise rejection
-					});
-					try {
-						const next = await v;
-						return [PROMISE_STATUS_FULFILLED, next];
-					} catch (e) {
-						return [PROMISE_STATUS_REJECTED, e];
-					}
-				})]
-			},
-		});
-	}
-	try {
-		yield recurse(value);
+  /**
+   * Recursively stringifies a value, handling promises specially
+   * @param {unknown} v The value to stringify
+   * @returns {string} The stringified value
+   */
+  function recurse(v) {
+    return stringify(v, {
+      ...revivers,
+      Promise: (v) => {
+        if (!isPromise(v)) {
+          return false;
+        }
+        return [
+          registerAsyncIterable(async function* (idx) {
+            // console.log('registerAsyncIterable', v);
+            v.catch(() => {
+              // prevent unhandled promise rejection
+            });
+            try {
+              const next = await v;
+              return `${idx}:${PROMISE_STATUS_FULFILLED}:${recurse(next)}`;
+            } catch (e) {
+              return `${idx}:${PROMISE_STATUS_REJECTED}:${recurse(e)}`;
+            }
+          }),
+        ];
+      },
+      AsyncIterable: (v) => {
+        if (!isAsyncIterable(v)) {
+          return false;
+        }
+        return [
+          registerAsyncIterable(async function* (idx) {
+            const iterator = v[Symbol.asyncIterator]();
+            try {
+              while (true) {
+                const next = await iterator.next();
+                if (next.done) {
+                  return `${idx}:${ASYNC_ITERABLE_STATUS_RETURN}:${recurse(
+                    next.value
+                  )}`;
+                }
+                yield `${idx}:${ASYNC_ITERABLE_STATUS_YIELD}:${recurse(
+                  next.value
+                )}`;
+              }
+            } catch (cause) {
+              return `${idx}:${ASYNC_ITERABLE_STATUS_ERROR}:${recurse(cause)}`;
+            } finally {
+              await iterator.return?.();
+            }
+          }),
+        ];
+      },
+    });
+  }
+  try {
+    yield recurse(value);
 
+    while (buffer.size) {
+      // Race all iterators to get the next value from any of them
+      const [entry, res] = await Promise.race(
+        Array.from(buffer).map(
+          async (it) => /** @type {const} */ ([it, await it.nextPromise])
+        )
+      );
 
-		while (buffer.size) {
-			// Race all iterators to get the next value from any of them
-			const [entry, res] = await Promise.race(
-				Array.from(buffer).map(async (it) => 
-					/** @type {const} */ ([it, await it.nextPromise]),
-				),
-			);
+      yield res.value;
 
-			yield recurse(res.value);
-
-
-			// Remove current iterator and re-add if not done
-			buffer.delete(entry);
-			if (!res.done) {
-				entry.nextPromise = entry.iterator.next();
-				buffer.add(entry);
-			}
-		}
-
-	} finally {
-		// Return all iterators
-		await Promise.allSettled(Array.from(buffer).map(it => it.iterator.return()));
-	}
+      // Remove current iterator and re-add if not done
+      buffer.delete(entry);
+      if (!res.done) {
+        entry.nextPromise = entry.iterator.next();
+        buffer.add(entry);
+      }
+    }
+  } finally {
+    // Return all iterators
+    await Promise.allSettled(
+      Array.from(buffer).map((it) => it.iterator.return())
+    );
+  }
 }
 
+function createStreamController() {
+  /** @type {ReadableStreamDefaultController<string | Error>} */
+  let originalController;
+  const stream = new ReadableStream({
+    start(controller) {
+      originalController = controller;
+    },
+  });
 
-export function parseStream() {
-    
+  return {
+    /** @param {unknown} v */
+    enqueue: (v) => originalController.enqueue(v),
+    getReader: () => stream.getReader(),
+  };
 }
 
 /**
- * Creates a ReadableStream from an AsyncIterable.
- * 
- * @param {AsyncIterable<unknown>} iterable The source AsyncIterable to stream from
- * @returns {ReadableStream} A ReadableStream that yields values from the AsyncIterable
+ * Converts a string to a number, throwing an error if the conversion fails
+ * @param {string} str The string to convert to a number
+ * @returns {number} The converted number
+ * @throws {Error} If the string cannot be converted to a number
  */
-export function readableStreamFrom(iterable) {
-	const iterator = iterable[Symbol.asyncIterator]();
-
-	return new ReadableStream({
-		async cancel() {
-			await iterator.return?.();
-		},
-
-		async pull(controller) {
-			const result = await iterator.next();
-
-			if (result.done) {
-				controller.close();
-				return;
-			}
-
-			controller.enqueue(result.value);
-		},
-	});
+function asNumberOrThrow(str) {
+  if (!/^\d+$/.test(str)) {
+    throw new Error(`Expected positive number, got ${str}`);
+  }
+  return parseInt(str, 10);
 }
-  
+
+/**
+ * Parse an async iterable value serialized with `devalue.stringify`
+ * @param {AsyncIterable<string>} value
+ * @param {Record<string, (value: any) => any>} [revivers]
+
+ * @returns {Promise<unknown>}
+ */
+export async function parseAsyncIterable(value, revivers = {}) {
+  const iterator = value[Symbol.asyncIterator]();
+
+  /** @type {Map<number, ReturnType<typeof createStreamController>>} */
+  const asyncMap = new Map();
+
+  /** @param {number} id */
+  function registerAsync(id) {
+    const controller = createStreamController();
+
+    asyncMap.set(id, controller);
+
+    return controller;
+  }
+
+  /** @param {string} value */
+  function recurse(value) {
+    console.log("recurse", value);
+    return parse(value, {
+      ...revivers,
+      Promise: async (v) => {
+        const [idx] = v;
+        const async = registerAsync(idx);
+
+        try {
+          const reader = async.getReader();
+
+          const result = await reader.read();
+
+          const [status, value] = result.value;
+
+          if (status === PROMISE_STATUS_FULFILLED) {
+            return value;
+          }
+
+          throw value;
+        } finally {
+          asyncMap.delete(idx);
+        }
+      },
+    });
+  }
+
+  // will contain the head of the async iterable
+  const head = await iterator.next();
+
+  if (!head.done) {
+    (async () => {
+      while (true) {
+        const result = await iterator.next();
+        if (result.done) break;
+
+        /** @type {string} */
+        let str = result.value;
+
+        console.log("str", str);
+
+        let index = str.indexOf(":");
+        let idx = asNumberOrThrow(str.slice(0, index));
+        str = str.slice(index + 1);
+
+        index = str.indexOf(":");
+        let status = asNumberOrThrow(str.slice(0, index));
+        str = str.slice(index + 1);
+
+        console.log({ idx, status, str });
+        const value = recurse(str);
+
+        asyncMap.get(idx)?.enqueue([status, value]);
+      }
+    })().catch((cause) => {
+      // go through all the asyncMap and enqueue the error
+      for (const [_, controller] of asyncMap) {
+        controller.enqueue([
+          ASYNC_ITERABLE_STATUS_ERROR,
+          new Error(
+            "Stream interrupted",
+            // @ts-ignore
+            { cause }
+          ),
+        ]);
+      }
+    });
+  }
+
+  return recurse(head.value);
+}

--- a/src/async.js
+++ b/src/async.js
@@ -244,11 +244,11 @@ export async function parseAsyncIterable(value, revivers = {}) {
         let str = result.value;
 
         let index = str.indexOf(":");
-        let idx = asNumberOrThrow(str.slice(0, index));
+        const idx = asNumberOrThrow(str.slice(0, index));
         str = str.slice(index + 1);
 
         index = str.indexOf(":");
-        let status = asNumberOrThrow(str.slice(0, index));
+        const status = asNumberOrThrow(str.slice(0, index));
         str = str.slice(index + 1);
 
         const value = recurse(str);

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ import * as vm from 'vm';
 import * as assert from 'uvu/assert';
 import * as uvu from 'uvu';
 import { uneval, unflatten, parse, stringify } from '../index.js';
+import { stringifyStream } from '../src/async.js';
 
 class Custom {
 	constructor(value) {
@@ -628,7 +629,26 @@ uvu.test('does not create duplicate parameter names', () => {
 	const bar = foo.map((_, i) => ({ [i]: foo[i] }));
 	const serialized = uneval([foo, ...bar]);
 
+
 	eval(serialized);
 });
+
+uvu.test.only('stringify stream', async () => {
+	const stream = stringifyStream({
+		promise: new Promise((resolve) => {
+			setTimeout(() => {
+				resolve('resolved');
+			}, 0);
+		}),
+	});
+
+	
+	for await (const value of stream) {
+		console.log('got:', value);
+	}
+
+	
+
+})
 
 uvu.test.run();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"diagnostics": true,
 		"noImplicitThis": true,
 		"noEmitOnError": true,
-		"lib": ["es6", "es2020"],
+		"lib": ["es6", "es2020", "DOM"],
 		"target": "es2020"
 	},
 	"module": "ES6",


### PR DESCRIPTION
This is a POC of being able to stringifying and parsing async values - e.g. `AsyncIterable` / `Promise` etc.

I had an evening where my fingers were twitching to hack on something and this idea has been playing in my mind for a while. 


### Background / why

I'm considering if we should use devalue as the transport in tRPC for any "text based" data instead of JSON. We already support out-of-order responses of batched requests, but it'd be nice to get it combined with a data transformer (devalue, superjson, etc) rather than having our own adapter.

It'd also allow devalue on streamed LLM responses etc


### What it does

```js
const source = {
	promise: (async () => {
		return 'resolved promise'
	})(),
	asyncIterable: (async function*() {
		yield -0
		yield 1
		yield 2;
		return 'returned async iterable'
	})(),
};
const stream = stringifyAsyncIterable(source);


/** @type {typeof source} */
const result = await parseAsyncIterable(withDebug(stream))


assert.equal(await result.promise, 'resolved promise')

const aggregate = []
const iterator = result.asyncIterable[Symbol.asyncIterator]()
while (true) {
	const next = await iterator.next()
	if (next.done) {
		assert.equal(next.value, 'returned async iterable')
		break
	}
	aggregate.push(next.value)
}


assert.equal(aggregate, [-0, 1, 2]);
```

## Question

Would this sort of behavior be of consideration in devalue at all?