### PR TITLE
feat: support URL

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -128,6 +128,12 @@ export function unflatten(parsed, revivers) {
             break;
           }
 
+					case 'URL': {
+						const url = new URL(value[1]);
+						hydrated[index] = url;
+						break;
+					}
+
 					default:
 						throw new Error(`Unknown type ${type}`);
 				}

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -90,6 +90,10 @@ export function stringify(value, reducers) {
 					str = `["Date","${valid ? thing.toISOString() : ''}"]`;
 					break;
 
+				case 'URL':
+					str = `["URL",${stringify_string(thing.href)}]`;
+					break;
+
 				case 'RegExp':
 					const { source, flags } = thing;
 					str = flags

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -59,6 +59,7 @@ export function uneval(value, replacer) {
 				case 'Boolean':
 				case 'Date':
 				case 'RegExp':
+				case 'URL':
 					return;
 
 				case 'Array':
@@ -166,6 +167,9 @@ export function uneval(value, replacer) {
 
 			case 'Date':
 				return `new Date(${thing.getTime()})`;
+
+			case 'URL':
+				return `new URL(${stringify_string(thing.href)})`;
 
 			case 'Array':
 				const members = /** @type {any[]} */ (thing).map((v, i) =>

--- a/test/test.js
+++ b/test/test.js
@@ -171,6 +171,12 @@ const fixtures = {
 			value: new Uint8Array([1, 2, 3]).buffer,
 			js: 'new Uint8Array([1,2,3]).buffer',
 			json: '[["ArrayBuffer","AQID"]]'
+		},
+		{
+			name: 'URL',
+			value: new URL('https://user:password@example.com/<script>/path?foo=bar#hash'),
+			js: 'new URL("https://user:password@example.com/%3Cscript%3E/path?foo=bar#hash")',
+			json: '[["URL","https://user:password@example.com/%3Cscript%3E/path?foo=bar#hash"]]'
 		}
 	],
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"diagnostics": true,
 		"noImplicitThis": true,
 		"noEmitOnError": true,
-		"lib": ["es6", "es2020"],
+		"lib": ["es6", "es2020", "dom"],
 		"target": "es2020"
 	},
 	"module": "ES6",


### PR DESCRIPTION
Fixes #79

`lib: ["dom"]` in tsconfig is necessary for TypeScript to know the `URL` constructor

`src/parse.js` indents with both tabs and spaces, should I add prettier/biome/whatever in an upcoming PR?