### PR TITLE
Fix a nasty bug with typed subarrays

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -153,7 +153,7 @@ export function stringify(value, reducers) {
 				case "BigUint64Array": {
 					/** @type {import("./types.js").TypedArray} */
 					const typedArray = thing;
-					const base64 = encode64(typedArray.buffer);
+					const base64 = encode64(typedArray.slice().buffer);
 					str = '["' + type + '","' + base64 + '"]';
 					break;
 				}


### PR DESCRIPTION
If you have a typed subarray for whatever reason, like using pbf's `readBytes`, devalue currently stringifies the whole buffer as shown in this example:

```js
import { parse, stringify } from "npm:devalue";

const buffer = new ArrayBuffer(100);
const view = new Uint8Array(buffer);
const subarray = view.subarray(0, 10);

console.log(subarray.length); // 10
console.log(parse(stringify(subarray)).length); // Incorrectly 100
```

This fixes that by calling `.slice()` first.