### PR TITLE
chore: simplify NullObject

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -9,11 +9,8 @@ class Custom {
 	}
 }
 
-const NullObject = (() => {
-	const C = function () {};
-	C.prototype = Object.create(null);
-	return C;
-})();
+function NullObject() {}
+NullObject.prototype = Object.create(null);
 
 const node_version = +process.versions.node.split('.')[0];
 


### PR DESCRIPTION
follow-up to #95 — @pi0 is there any reason it isn't just this? the IIFE is redundant surely?