### PR TITLE
chore: Remove nonexistent function from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If a function passed to `stringify` returns a truthy value, it's treated as a ma
 You can also use custom types with `uneval` by specifying a custom replacer:
 
 ```js
-devalue.uneval(vector, (value, uneval) => {
+devalue.uneval(vector, (value) => {
 	if (value instanceof Vector) {
 		return `new Vector(${value.x},${value.y})`;
 	}


### PR DESCRIPTION
`uneval` does not exist as a second parameter to the replacer function. Maybe it did in the past?