### PR TITLE
chore: Remove impossible `void` type from replacer's `uneval`

### DIFF
--- a/.changeset/some-buttons-scream.md
+++ b/.changeset/some-buttons-scream.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+chore: Remove impossible `void` type from replacer's `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -17,7 +17,7 @@ const reserved =
 /**
  * Turn a value into the JavaScript that creates an equivalent value
  * @param {any} value
- * @param {(value: any, uneval: (value: any) => string | void) => string | void} [replacer]
+ * @param {(value: any, uneval: (value: any) => string) => string | void} [replacer]
  */
 export function uneval(value, replacer) {
 	const counts = new Map();


### PR DESCRIPTION
My understanding is, this nested `uneval` must always return a string, because:
- It will run custom replacers, which may return `string | void`
- If the custom replacers return `void`, it will fall back to builtins, which will return `string`, or
- It will throw because nothing can serialize the object in question

