### PR TITLE
fix: allow custom revivers to revive things serialized by buitin reducers

### DIFF
--- a/.changeset/fresh-lights-battle.md
+++ b/.changeset/fresh-lights-battle.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: allow custom revivers to revive things serialized by builtin reducers

--- a/src/parse.js
+++ b/src/parse.js
@@ -60,7 +60,13 @@ export function unflatten(parsed, revivers) {
 
 				const reviver = revivers?.[type];
 				if (reviver) {
-					return (hydrated[index] = reviver(hydrate(value[1])));
+					let i = value[1];
+					if (typeof i !== 'number') {
+						// if it's not a number, it was serialized by a builtin reviver
+						// so we need to munge it into the format expected by a custom reviver
+						i = values.push(value[1]) - 1;
+					}
+					return (hydrated[index] = reviver(hydrate(i)));
 				}
 
 				switch (type) {

--- a/test/test.js
+++ b/test/test.js
@@ -582,7 +582,27 @@ const fixtures = {
 				assert.equal(obj1.value.bar.value.answer, 42);
 			}
 		}
-	])(new Foo({ bar: new Bar({ answer: 42 }) }))
+	])(new Foo({ bar: new Bar({ answer: 42 }) })),
+
+	custom_fallback: ((date) => [
+		{
+			name: 'Custom fallback',
+			value: date,
+			js: "new Date('')",
+			json: '[["Date",""]]',
+			replacer: (value) => value instanceof Date && `new Date('')`,
+			reducers: {
+				Date: (value) => value instanceof Date && '',
+			},
+			revivers: {
+				Date: (value) => new Date(value)
+			},
+			validate: (obj) => {
+				assert.ok(obj instanceof Date);
+				assert.ok(isNaN(obj.getDate()));
+			}
+		}
+	])(new Date('invalid'))
 };
 
 for (const [name, tests] of Object.entries(fixtures)) {


### PR DESCRIPTION
Basically, before this change, if you serialized a builtin but invalid date:


```ts
const stringified = devalue.stringify(new Date('invalid'));

console.log(stringified); // [["Date", ""]]

const date = devalue.parse(stringified, {
	Date: (value) => new Date(value)
});
```

You'd get an error that you'd provided invalid input -- because we'd feed the default-replaced value into the custom reviver, which expects a different format. This is uniquely the case when overriding builtin revivers. 

After this change, this won't throw an error -- it will just work.