### PR TITLE
Enable support for custom reducer/reviver for "function" values

### DIFF
--- a/.changeset/moody-bees-jog.md
+++ b/.changeset/moody-bees-jog.md
@@ -1,0 +1,5 @@
+---
+"devalue": minor
+---
+
+Enable support for custom reducer/reviver for "function" values

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -44,10 +44,6 @@ export function stringify(value, reducers) {
 
 	/** @param {any} thing */
 	function flatten(thing) {
-		if (typeof thing === 'function') {
-			throw new DevalueError(`Cannot stringify a function`, keys);
-		}
-
 		if (thing === undefined) return UNDEFINED;
 		if (Number.isNaN(thing)) return NAN;
 		if (thing === Infinity) return POSITIVE_INFINITY;
@@ -65,6 +61,10 @@ export function stringify(value, reducers) {
 				stringified[index] = `["${key}",${flatten(value)}]`;
 				return index;
 			}
+		}
+
+		if (typeof thing === 'function') {
+			throw new DevalueError(`Cannot stringify a function`, keys);
 		}
 
 		let str = '';

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -29,10 +29,6 @@ export function uneval(value, replacer) {
 
 	/** @param {any} thing */
 	function walk(thing) {
-		if (typeof thing === 'function') {
-			throw new DevalueError(`Cannot stringify a function`, keys);
-		}
-
 		if (!is_primitive(thing)) {
 			if (counts.has(thing)) {
 				counts.set(thing, counts.get(thing) + 1);
@@ -48,6 +44,10 @@ export function uneval(value, replacer) {
 					custom.set(thing, str);
 					return;
 				}
+			}
+
+			if (typeof thing === 'function') {
+				throw new DevalueError(`Cannot stringify a function`, keys);
 			}
 
 			const type = get_type(thing);


### PR DESCRIPTION
Moves the `typeof value === 'function'` error throw to after checking if a custom reducer/reviver decided it wants to handle serialization of the value, to allow function references to be serialized.