### PR TITLE
fix: add hasOwn check before calling reviver

### DIFF
--- a/.changeset/happy-emus-fry.md
+++ b/.changeset/happy-emus-fry.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: add hasOwn check before calling reviver

--- a/src/parse.js
+++ b/src/parse.js
@@ -58,7 +58,11 @@ export function unflatten(parsed, revivers) {
 			if (typeof value[0] === 'string') {
 				const type = value[0];
 
-				const reviver = revivers?.[type];
+				const reviver =
+					revivers && Object.hasOwn(revivers, type)
+						? revivers[type]
+						: undefined;
+
 				if (reviver) {
 					let i = value[1];
 					if (typeof i !== 'number') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
 		"diagnostics": true,
 		"noImplicitThis": true,
 		"noEmitOnError": true,
-		"lib": ["es6", "es2020", "dom"],
-		"target": "es2020"
+		"lib": ["es6", "esnext", "dom"],
+		"target": "esnext"
 	},
 	"module": "ES6",
 	"include": ["index.js", "src/*.js"],


### PR DESCRIPTION
This guards against the extremely remote possibility that `unflatten` could be called with a second argument that isn't a POJO, or that a payload could reference a method on a polluted `Object.prototype`