### PR TITLE
feat: whitelist `Float16Array`

### DIFF
--- a/.changeset/common-ducks-agree.md
+++ b/.changeset/common-ducks-agree.md
@@ -1,0 +1,5 @@
+---
+"devalue": minor
+---
+
+feat: whitelist `Float16Array`

--- a/src/parse.js
+++ b/src/parse.js
@@ -148,6 +148,7 @@ export function unflatten(parsed, revivers) {
 					case 'Uint8ClampedArray':
 					case 'Int16Array':
 					case 'Uint16Array':
+					case 'Float16Array':
 					case 'Int32Array':
 					case 'Uint32Array':
 					case 'Float32Array':

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -220,6 +220,7 @@ export function stringify(value, reducers) {
 				case 'Uint8ClampedArray':
 				case 'Int16Array':
 				case 'Uint16Array':
+				case 'Float16Array':
 				case 'Int32Array':
 				case 'Uint32Array':
 				case 'Float32Array':

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,1 +1,1 @@
-export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
+export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Float16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -91,6 +91,7 @@ export function uneval(value, replacer) {
 				case 'Uint8ClampedArray':
 				case 'Int16Array':
 				case 'Uint16Array':
+				case 'Float16Array':
 				case 'Int32Array':
 				case 'Uint32Array':
 				case 'Float32Array':
@@ -289,6 +290,7 @@ export function uneval(value, replacer) {
 			case 'Uint8ClampedArray':
 			case 'Int16Array':
 			case 'Uint16Array':
+			case 'Float16Array':
 			case 'Int32Array':
 			case 'Uint32Array':
 			case 'Float32Array':


### PR DESCRIPTION
No big changes required for this one: `Float16Array`'s API is the same as other typed arrays and any endianness concerns are the same as `Float32Array`'s.

Closes #96.