### PR TITLE
feat: add `stringifyAsync` for async serialization

### DIFF
--- a/.changeset/async-serialization.md
+++ b/.changeset/async-serialization.md
@@ -1,0 +1,5 @@
+---
+"devalue": minor
+---
+
+feat: add `stringifyAsync` for async serialization

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Like `JSON.stringify`, but handles
 - `URL` and `URLSearchParams`
 - `Temporal`
 - custom types via replacers, reducers and revivers
+- promises (via `stringifyAsync`)
 
 Try it out [here](https://svelte.dev/repl/138d70def7a748ce9eda736ef1c71239?version=3.49.0).
 
@@ -67,6 +68,32 @@ devalue.parse(stringified); // { message: 'hello', self: [Circular] }
 ```
 
 Use `stringify` and `parse` when evaluating JavaScript isn't an option.
+
+### `stringifyAsync` and `parse`
+
+`stringifyAsync` is an async version of `stringify` that can handle promises in the value graph and async reducers:
+
+```js
+import * as devalue from 'devalue';
+
+let obj = {
+  quick: 'data',
+  slow: fetch('/api/slow').then((r) => r.json())
+};
+
+let stringified = await devalue.stringifyAsync(obj);
+devalue.parse(stringified); // { quick: 'data', slow: { ... } }
+```
+
+Promises are awaited and their resolved values are serialized. The output format is identical to `stringify`, so `parse` and `unflatten` work unchanged.
+
+Reducers can also be async:
+
+```js
+const stringified = await devalue.stringifyAsync(value, {
+  User: async (value) => value instanceof User && (await fetchUserData(value.id))
+});
+```
 
 ### `unflatten`
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { uneval } from './src/uneval.js';
 export { parse, unflatten } from './src/parse.js';
 export { stringify } from './src/stringify.js';
+export { stringifyAsync } from './src/stringify-async.js';
 export { DevalueError } from './src/utils.js';

--- a/src/stringify-async.js
+++ b/src/stringify-async.js
@@ -1,0 +1,306 @@
+import {
+	DevalueError,
+	enumerable_symbols,
+	get_type,
+	is_plain_object,
+	is_primitive,
+	stringify_key,
+	stringify_string,
+	valid_array_indices
+} from './utils.js';
+import {
+	HOLE,
+	NAN,
+	NEGATIVE_INFINITY,
+	NEGATIVE_ZERO,
+	POSITIVE_INFINITY,
+	SPARSE,
+	UNDEFINED
+} from './constants.js';
+import { encode64 } from './base64.js';
+
+/**
+ * Async version of `stringify` that resolves promises in the value graph
+ * and supports async reducers. Returns a JSON string in the same format
+ * as `stringify`, so `parse` and `unflatten` work unchanged.
+ * @param {any} value
+ * @param {Record<string, (value: any) => any>} [reducers]
+ * @returns {Promise<string>}
+ */
+export async function stringifyAsync(value, reducers) {
+	/** @type {any[]} */
+	const stringified = [];
+
+	/** @type {Map<any, number>} */
+	const indexes = new Map();
+
+	/** @type {Array<{ key: string, fn: (value: any) => any }>} */
+	const custom = [];
+	if (reducers) {
+		for (const key of Object.getOwnPropertyNames(reducers)) {
+			custom.push({ key, fn: reducers[key] });
+		}
+	}
+
+	/** @type {string[]} */
+	const keys = [];
+
+	let p = 0;
+
+	/** @param {any} thing */
+	async function flatten(thing) {
+		// Resolve thenables/Promises before processing
+		if (thing !== null && typeof thing === 'object' && typeof thing.then === 'function') {
+			thing = await thing;
+		}
+
+		if (thing === undefined) return UNDEFINED;
+		if (Number.isNaN(thing)) return NAN;
+		if (thing === Infinity) return POSITIVE_INFINITY;
+		if (thing === -Infinity) return NEGATIVE_INFINITY;
+		if (thing === 0 && 1 / thing < 0) return NEGATIVE_ZERO;
+
+		if (indexes.has(thing)) return /** @type {number} */ (indexes.get(thing));
+
+		const index = p++;
+		indexes.set(thing, index);
+
+		for (const { key, fn } of custom) {
+			let value = fn(thing);
+			// Allow reducers to return Promises
+			if (value !== null && typeof value === 'object' && typeof value.then === 'function') {
+				value = await value;
+			}
+			if (value) {
+				stringified[index] = `["${key}",${await flatten(value)}]`;
+				return index;
+			}
+		}
+
+		if (typeof thing === 'function') {
+			throw new DevalueError(`Cannot stringify a function`, keys, thing, value);
+		} else if (typeof thing === 'symbol') {
+			throw new DevalueError(`Cannot stringify a Symbol primitive`, keys, thing, value);
+		}
+
+		let str = '';
+
+		if (is_primitive(thing)) {
+			str = stringify_primitive(thing);
+		} else {
+			const type = get_type(thing);
+
+			switch (type) {
+				case 'Number':
+				case 'String':
+				case 'Boolean':
+				case 'BigInt':
+					str = `["Object",${await flatten(thing.valueOf())}]`;
+					break;
+
+				case 'Date':
+					const valid = !isNaN(thing.getDate());
+					str = `["Date","${valid ? thing.toISOString() : ''}"]`;
+					break;
+
+				case 'URL':
+					str = `["URL",${stringify_string(thing.toString())}]`;
+					break;
+
+				case 'URLSearchParams':
+					str = `["URLSearchParams",${stringify_string(thing.toString())}]`;
+					break;
+
+				case 'RegExp':
+					const { source, flags } = thing;
+					str = flags
+						? `["RegExp",${stringify_string(source)},"${flags}"]`
+						: `["RegExp",${stringify_string(source)}]`;
+					break;
+
+				case 'Array': {
+					let mostly_dense = false;
+
+					str = '[';
+
+					for (let i = 0; i < thing.length; i += 1) {
+						if (i > 0) str += ',';
+
+						if (Object.hasOwn(thing, i)) {
+							keys.push(`[${i}]`);
+							str += await flatten(thing[i]);
+							keys.pop();
+						} else if (mostly_dense) {
+							str += HOLE;
+						} else {
+							const populated_keys = valid_array_indices(/** @type {any[]} */ (thing));
+							const population = populated_keys.length;
+							const d = String(thing.length).length;
+
+							const hole_cost = (thing.length - population) * 3;
+							const sparse_cost = 4 + d + population * (d + 1);
+
+							if (hole_cost > sparse_cost) {
+								str = '[' + SPARSE + ',' + thing.length;
+								for (let j = 0; j < populated_keys.length; j++) {
+									const key = populated_keys[j];
+									keys.push(`[${key}]`);
+									str += ',' + key + ',' + (await flatten(thing[key]));
+									keys.pop();
+								}
+								break;
+							} else {
+								mostly_dense = true;
+								str += HOLE;
+							}
+						}
+					}
+
+					str += ']';
+
+					break;
+				}
+
+				case 'Set':
+					str = '["Set"';
+
+					for (const value of thing) {
+						str += `,${await flatten(value)}`;
+					}
+
+					str += ']';
+					break;
+
+				case 'Map':
+					str = '["Map"';
+
+					for (const [key, value] of thing) {
+						keys.push(`.get(${is_primitive(key) ? stringify_primitive(key) : '...'})`);
+						str += `,${await flatten(key)},${await flatten(value)}`;
+						keys.pop();
+					}
+
+					str += ']';
+					break;
+
+				case 'Int8Array':
+				case 'Uint8Array':
+				case 'Uint8ClampedArray':
+				case 'Int16Array':
+				case 'Uint16Array':
+				case 'Float16Array':
+				case 'Int32Array':
+				case 'Uint32Array':
+				case 'Float32Array':
+				case 'Float64Array':
+				case 'BigInt64Array':
+				case 'BigUint64Array':
+				case 'DataView': {
+					/** @type {import("./types.js").TypedArray} */
+					const typedArray = thing;
+					str = '["' + type + '",' + (await flatten(typedArray.buffer));
+
+					// handle subarrays
+					if (typedArray.byteLength !== typedArray.buffer.byteLength) {
+						// to be used with `new TypedArray(buffer, byteOffset, length)`
+						str += `,${typedArray.byteOffset},${typedArray.length}`;
+					}
+
+					str += ']';
+					break;
+				}
+
+				case 'ArrayBuffer': {
+					/** @type {ArrayBuffer} */
+					const arraybuffer = thing;
+					const base64 = encode64(arraybuffer);
+
+					str = `["ArrayBuffer","${base64}"]`;
+					break;
+				}
+
+				case 'Temporal.Duration':
+				case 'Temporal.Instant':
+				case 'Temporal.PlainDate':
+				case 'Temporal.PlainTime':
+				case 'Temporal.PlainDateTime':
+				case 'Temporal.PlainMonthDay':
+				case 'Temporal.PlainYearMonth':
+				case 'Temporal.ZonedDateTime':
+					str = `["${type}",${stringify_string(thing.toString())}]`;
+					break;
+
+				default:
+					if (!is_plain_object(thing)) {
+						throw new DevalueError(`Cannot stringify arbitrary non-POJOs`, keys, thing, value);
+					}
+
+					if (enumerable_symbols(thing).length > 0) {
+						throw new DevalueError(`Cannot stringify POJOs with symbolic keys`, keys, thing, value);
+					}
+
+					if (Object.getPrototypeOf(thing) === null) {
+						str = '["null"';
+						for (const key of Object.keys(thing)) {
+							if (key === '__proto__') {
+								throw new DevalueError(
+									`Cannot stringify objects with __proto__ keys`,
+									keys,
+									thing,
+									value
+								);
+							}
+
+							keys.push(stringify_key(key));
+							str += `,${stringify_string(key)},${await flatten(thing[key])}`;
+							keys.pop();
+						}
+						str += ']';
+					} else {
+						str = '{';
+						let started = false;
+						for (const key of Object.keys(thing)) {
+							if (key === '__proto__') {
+								throw new DevalueError(
+									`Cannot stringify objects with __proto__ keys`,
+									keys,
+									thing,
+									value
+								);
+							}
+
+							if (started) str += ',';
+							started = true;
+							keys.push(stringify_key(key));
+							str += `${stringify_string(key)}:${await flatten(thing[key])}`;
+							keys.pop();
+						}
+						str += '}';
+					}
+			}
+		}
+
+		stringified[index] = str;
+		return index;
+	}
+
+	const index = await flatten(value);
+
+	// special case — value is represented as a negative index
+	if (index < 0) return `${index}`;
+
+	return `[${stringified.join(',')}]`;
+}
+
+/**
+ * @param {any} thing
+ * @returns {string}
+ */
+function stringify_primitive(thing) {
+	const type = typeof thing;
+	if (type === 'string') return stringify_string(thing);
+	if (thing === void 0) return UNDEFINED.toString();
+	if (thing === 0 && 1 / thing < 0) return NEGATIVE_ZERO.toString();
+	if (type === 'bigint') return `["BigInt","${thing}"]`;
+	return String(thing);
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@ import * as vm from 'vm';
 import * as assert from 'uvu/assert';
 import * as uvu from 'uvu';
 import * as consts from '../src/constants.js';
-import { uneval, unflatten, parse, stringify } from '../index.js';
+import { uneval, unflatten, parse, stringify, stringifyAsync } from '../index.js';
 
 globalThis.Temporal ??= (await import('@js-temporal/polyfill')).Temporal;
 
@@ -1422,3 +1422,232 @@ uvu.test('valid sparse array parses correctly', () => {
 });
 
 uvu.test.run();
+
+// --- stringifyAsync tests ---
+
+// Verify that stringifyAsync produces identical output to stringify for all fixtures
+for (const [name, tests] of Object.entries(fixtures)) {
+	const test = uvu.suite(`stringifyAsync: ${name}`);
+	for (const t of tests) {
+		test(t.name, async () => {
+			const actual = await stringifyAsync(t.value, t.reducers);
+			const expected = t.json;
+			assert.equal(actual, expected);
+		});
+	}
+	test.run();
+}
+
+// Verify round-trip: stringifyAsync output can be parsed back
+for (const [name, tests] of Object.entries(fixtures)) {
+	const test = uvu.suite(`stringifyAsync round-trip: ${name}`);
+	for (const t of tests) {
+		test(t.name, async () => {
+			const json = await stringifyAsync(t.value, t.reducers);
+			const actual = parse(json, t.revivers);
+
+			if (t.validate) {
+				t.validate(actual);
+			} else {
+				assert.equal(actual, t.value);
+			}
+		});
+	}
+	test.run();
+}
+
+// Async-specific tests
+const asyncTests = uvu.suite('stringifyAsync: promises');
+
+asyncTests('resolves top-level promise', async () => {
+	const result = await stringifyAsync(Promise.resolve(42));
+	assert.equal(result, stringify(42));
+});
+
+asyncTests('resolves promise to undefined', async () => {
+	const result = await stringifyAsync(Promise.resolve(undefined));
+	assert.equal(result, stringify(undefined));
+});
+
+asyncTests('resolves promise to null', async () => {
+	const result = await stringifyAsync(Promise.resolve(null));
+	assert.equal(result, stringify(null));
+});
+
+asyncTests('resolves promise to NaN', async () => {
+	const result = await stringifyAsync(Promise.resolve(NaN));
+	assert.equal(result, stringify(NaN));
+});
+
+asyncTests('resolves nested promises in objects', async () => {
+	const result = await stringifyAsync({
+		a: Promise.resolve(1),
+		b: Promise.resolve('hello')
+	});
+	assert.equal(result, stringify({ a: 1, b: 'hello' }));
+});
+
+asyncTests('resolves promises in arrays', async () => {
+	const result = await stringifyAsync([
+		Promise.resolve('a'),
+		Promise.resolve('b')
+	]);
+	assert.equal(result, stringify(['a', 'b']));
+});
+
+asyncTests('resolves promises in Sets', async () => {
+	const result = await stringifyAsync(new Set([Promise.resolve(1), Promise.resolve(2)]));
+	assert.equal(result, stringify(new Set([1, 2])));
+});
+
+asyncTests('resolves promises in Map values', async () => {
+	const result = await stringifyAsync(new Map([['key', Promise.resolve('value')]]));
+	assert.equal(result, stringify(new Map([['key', 'value']])));
+});
+
+asyncTests('resolves deeply nested promises', async () => {
+	const result = await stringifyAsync({
+		a: { b: { c: Promise.resolve(42) } }
+	});
+	assert.equal(result, stringify({ a: { b: { c: 42 } } }));
+});
+
+asyncTests('deduplicates resolved values by identity', async () => {
+	const obj = { x: 1 };
+	const promise = Promise.resolve(obj);
+	const result = await stringifyAsync([promise, promise]);
+	assert.equal(result, stringify([obj, obj]));
+});
+
+asyncTests('handles thenables', async () => {
+	const thenable = { then: (resolve) => resolve(42) };
+	const result = await stringifyAsync(thenable);
+	assert.equal(result, stringify(42));
+});
+
+asyncTests('propagates rejected promises', async () => {
+	try {
+		await stringifyAsync(Promise.reject(new Error('fail')));
+		assert.unreachable('should have thrown');
+	} catch (e) {
+		assert.equal(e.message, 'fail');
+	}
+});
+
+asyncTests('resolves promise to complex value', async () => {
+	const complex = { date: new Date(1e12), set: new Set([1, 2]), arr: [3, 4] };
+	const result = await stringifyAsync(Promise.resolve(complex));
+	assert.equal(result, stringify(complex));
+});
+
+asyncTests('resolves mixed sync and async values', async () => {
+	const result = await stringifyAsync({
+		sync: 'hello',
+		async: Promise.resolve('world'),
+		nested: {
+			sync: 42,
+			async: Promise.resolve([1, 2, 3])
+		}
+	});
+	assert.equal(
+		result,
+		stringify({
+			sync: 'hello',
+			async: 'world',
+			nested: {
+				sync: 42,
+				async: [1, 2, 3]
+			}
+		})
+	);
+});
+
+asyncTests.run();
+
+// Async reducer tests
+const asyncReducerTests = uvu.suite('stringifyAsync: async reducers');
+
+asyncReducerTests('supports async reducers', async () => {
+	const result = await stringifyAsync(new Foo({ answer: 42 }), {
+		Foo: async (x) => x instanceof Foo && x.value
+	});
+	const expected = stringify(new Foo({ answer: 42 }), {
+		Foo: (x) => x instanceof Foo && x.value
+	});
+	assert.equal(result, expected);
+});
+
+asyncReducerTests('supports mix of sync and async reducers', async () => {
+	const result = await stringifyAsync([new Foo({ val: 1 }), new Bar({ val: 2 })], {
+		Foo: async (x) => x instanceof Foo && x.value,
+		Bar: (x) => x instanceof Bar && x.value
+	});
+	const expected = stringify([new Foo({ val: 1 }), new Bar({ val: 2 })], {
+		Foo: (x) => x instanceof Foo && x.value,
+		Bar: (x) => x instanceof Bar && x.value
+	});
+	assert.equal(result, expected);
+});
+
+asyncReducerTests('async reducer with promise values', async () => {
+	const result = await stringifyAsync(
+		{ data: Promise.resolve(new Foo({ answer: 42 })) },
+		{
+			Foo: async (x) => x instanceof Foo && x.value
+		}
+	);
+	const expected = stringify(
+		{ data: new Foo({ answer: 42 }) },
+		{
+			Foo: (x) => x instanceof Foo && x.value
+		}
+	);
+	assert.equal(result, expected);
+});
+
+asyncReducerTests.run();
+
+// Error handling with stringifyAsync
+const asyncErrorTests = uvu.suite('stringifyAsync: errors');
+
+asyncErrorTests('throws for functions', async () => {
+	try {
+		await stringifyAsync(function invalid() {});
+		assert.unreachable('should have thrown');
+	} catch (e) {
+		assert.equal(e.name, 'DevalueError');
+		assert.equal(e.message, 'Cannot stringify a function');
+	}
+});
+
+asyncErrorTests('throws for Symbols', async () => {
+	try {
+		await stringifyAsync(Symbol('foo'));
+		assert.unreachable('should have thrown');
+	} catch (e) {
+		assert.equal(e.name, 'DevalueError');
+	}
+});
+
+asyncErrorTests('throws for non-POJOs without reducer', async () => {
+	class Whatever {}
+	try {
+		await stringifyAsync(new Whatever());
+		assert.unreachable('should have thrown');
+	} catch (e) {
+		assert.equal(e.name, 'DevalueError');
+		assert.equal(e.message, 'Cannot stringify arbitrary non-POJOs');
+	}
+});
+
+asyncErrorTests('throws for promise resolving to function', async () => {
+	try {
+		await stringifyAsync(Promise.resolve(function invalid() {}));
+		assert.unreachable('should have thrown');
+	} catch (e) {
+		assert.equal(e.name, 'DevalueError');
+		assert.equal(e.message, 'Cannot stringify a function');
+	}
+});
+
+asyncErrorTests.run();


### PR DESCRIPTION
[Preview](https://github.com/gr2m/devalue/blob/async-serialization/README.md#stringifyasync-and-parse) 👀 

Async version of `stringify` that resolves promises in the value graph and supports async reducers. Returns a `Promise<string>` in the same format as `stringify`, so `parse` and `unflatten` work unchanged.

Addresses #148 (async serialization portion).

```js
import { stringifyAsync, parse } from 'devalue';

// Promises in the value graph are awaited automatically
const json = await stringifyAsync({
  sync: 'hello',
  async: Promise.resolve('world')
});
parse(json); // { sync: 'hello', async: 'world' }

// Reducers can be async
const json2 = await stringifyAsync(value, {
  User: async (v) => v instanceof User && (await fetchUserData(v.id))
});
```