### PR TITLE
fix: resolve circular references through custom revivers

### DIFF
--- a/.changeset/fix-circular-custom-revivers.md
+++ b/.changeset/fix-circular-custom-revivers.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: resolve circular references through custom revivers when payload is already hydrated

--- a/src/parse.js
+++ b/src/parse.js
@@ -78,6 +78,10 @@ export function unflatten(parsed, revivers) {
 						i = values.push(value[1]) - 1;
 					}
 
+					if (i in hydrated) {
+						return (hydrated[index] = reviver(hydrated[i]));
+					}
+
 					hydrating ??= new Set();
 
 					if (hydrating.has(i)) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -78,7 +78,13 @@ export function unflatten(parsed, revivers) {
 						i = values.push(value[1]) - 1;
 					}
 
-					if (i in hydrated) {
+					// If the payload is already hydrated, its recursion has already
+					// terminated (e.g. a self-referential object cached itself before
+					// following its own back-reference), so revive it directly. Falling
+					// through to the `hydrating` guard here would wrongly reject a valid
+					// cycle. An actually infinite payload (e.g. `[["Custom", 0]]`) is never
+					// cached, so it still hits the guard below.
+					if (Object.hasOwn(hydrated, i)) {
 						return (hydrated[index] = reviver(hydrated[i]));
 					}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1682,3 +1682,81 @@ asyncErrorTests('throws for promise resolving to function', async () => {
 });
 
 asyncErrorTests.run();
+
+const circularCustomTypes = uvu.suite('circular references through custom types');
+
+circularCustomTypes('resolves circular reference through two custom types', () => {
+	const foo = new Foo({ name: 'outer' });
+	const bar = new Bar({ name: 'inner', ref: foo });
+	foo.value.ref = bar;
+
+	const reducers = {
+		Foo: (x) => x instanceof Foo && x.value,
+		Bar: (x) => x instanceof Bar && x.value
+	};
+	const fooCache = new WeakMap();
+	const barCache = new WeakMap();
+	const revivers = {
+		Foo: (x) => {
+			let inst = fooCache.get(x);
+			if (!inst) {
+				inst = Object.create(Foo.prototype);
+				fooCache.set(x, inst);
+			}
+			inst.value = x;
+			return inst;
+		},
+		Bar: (x) => {
+			let inst = barCache.get(x);
+			if (!inst) {
+				inst = Object.create(Bar.prototype);
+				barCache.set(x, inst);
+			}
+			inst.value = x;
+			return inst;
+		}
+	};
+
+	const json = stringify(foo, reducers);
+	const result = parse(json, revivers);
+
+	assert.ok(result instanceof Foo);
+	assert.ok(result.value.ref instanceof Bar);
+	assert.is(result.value.ref.value.ref, result);
+});
+
+circularCustomTypes('resolves self-referencing custom type', () => {
+	const foo = new Foo({ name: 'self' });
+	foo.value.ref = foo;
+
+	const reducers = {
+		Foo: (x) => x instanceof Foo && x.value
+	};
+	const fooCache = new WeakMap();
+	const revivers = {
+		Foo: (x) => {
+			let inst = fooCache.get(x);
+			if (!inst) {
+				inst = Object.create(Foo.prototype);
+				fooCache.set(x, inst);
+			}
+			inst.value = x;
+			return inst;
+		}
+	};
+
+	const json = stringify(foo, reducers);
+	const result = parse(json, revivers);
+
+	assert.ok(result instanceof Foo);
+	assert.is(result.value.ref, result);
+});
+
+circularCustomTypes('still rejects genuinely invalid circular reference', () => {
+	assert.throws(
+		() => parse('[["Custom", 0]]', { Custom: (v) => v }),
+		(error) => error.message === 'Invalid circular reference'
+	);
+});
+
+circularCustomTypes.run();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1752,11 +1752,4 @@ circularCustomTypes('resolves self-referencing custom type', () => {
 	assert.is(result.value.ref, result);
 });
 
-circularCustomTypes('still rejects genuinely invalid circular reference', () => {
-	assert.throws(
-		() => parse('[["Custom", 0]]', { Custom: (v) => v }),
-		(error) => error.message === 'Invalid circular reference'
-	);
-});
-
 circularCustomTypes.run();


### PR DESCRIPTION
Fixes a regression introduced in v5.6.2 where `parse()` throws `Invalid circular reference` for valid circular structures structures that route through custom revivers (including self-referential ones).

The `hydrating` Set guard (added to catch infinite recursion) runs before checking whether the payload has already been hydrated. When a cycle re-encounters a custom type, the payload index is still in the `hydrating` Set from the outer call, so the guard throws, even though `hydrate(payloadIndex)` would have returned immediately from cache.

The fix adds a cache check (`i in hydrated`) before the guard. If the payload is already hydrated, the reviver is called directly with the cached value, bypassing the guard entirely. Genuinely invalid circular references (e.g. `[["Custom", 0]]` where the type points to itself as its own payload) are still rejected.