### PR TITLE
chore(ci): set permissions on ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 # cancel in-progress runs on new commits to same PR (gitub.event.number)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   Tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to `.github/workflows/ci.yml`. The job only reads the repository, so `contents: read` is sufficient; today the workflow inherits whatever the repository default grants, which is broader than it needs. This is one of the checks OpenSSF Scorecard flags under [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).