### PR TITLE
fix: uneval grows sparse arrays by one slot when first hole is past index 0

### DIFF
--- a/.changeset/uneval-sparse-array-extra-comma.md
+++ b/.changeset/uneval-sparse-array-extra-comma.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: do not grow sparse arrays by one slot in uneval

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -260,9 +260,11 @@ export function uneval(value, replacer) {
 							return `Object.assign(Array(${thing.length}),{${entries}})`;
 						}
 
-						// Re-process this index as a hole in the array literal
+						// Switch to hole mode. The comma separator emitted at the
+						// top of this iteration already represents this first hole,
+						// so we must not re-process the index (doing so would emit a
+						// second comma and grow the array by one slot).
 						has_holes = true;
-						i -= 1;
 					}
 					// else: already decided on array literal, hole is just an empty slot
 					// (the comma separator is all we need — no content for this position)

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -260,10 +260,6 @@ export function uneval(value, replacer) {
 							return `Object.assign(Array(${thing.length}),{${entries}})`;
 						}
 
-						// Switch to hole mode. The comma separator emitted at the
-						// top of this iteration already represents this first hole,
-						// so we must not re-process the index (doing so would emit a
-						// second comma and grow the array by one slot).
 						has_holes = true;
 					}
 					// else: already decided on array literal, hole is just an empty slot

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1310,6 +1310,17 @@ uvu.test('ignores non-numeric array properties in dense encoding', () => {
 	assert.ok(!(0 in parsed));
 });
 
+uvu.test('uneval round-trips sparse arrays whose first hole is not at index 0', () => {
+	for (const arr of [[1, , 3], [1, ,], [1, , , 4], [1, 2, , 4]]) {
+		const evaled = (0, eval)(uneval(arr));
+		assert.is(evaled.length, arr.length, `length for keys ${Object.keys(arr).join(',')}`);
+		assert.equal(Object.keys(evaled), Object.keys(arr));
+		for (const k of Object.keys(arr)) {
+			assert.is(evaled[k], arr[k]);
+		}
+	}
+});
+
 uvu.test('ignores non-numeric array properties in sparse encoding', () => {
 	// Sparse path (very sparse — Object.assign / SPARSE encoding wins)
 	const arr = [];


### PR DESCRIPTION
### What

`uneval` grows a sparse array by one slot when its first hole is not at index 0:

```js
import { uneval } from 'devalue';

uneval([1, , 3]);   // '[1,,,3]'  → evaluates to [1, <2 empty>, 3], length 4
uneval([1, , ]);    // '[1,,,]'   → length 3
uneval([1, , , 4]); // '[1,,,,4]' → length 5
```

`stringify`/`parse` round-trips these correctly — only `uneval` is affected. (`[, 'a']`, where the first hole is at index 0, was already correct, which is why this slipped through.)

### Why

In the array-literal branch, a comma is written at the top of every iteration (`if (i > 0) result += ','`). When the first hole is reached, the code set `has_holes = true` and then did `i -= 1` to "re-process this index as a hole" — but the re-processed iteration writes a **second** comma for the same slot, so each such array gains one element.

### Fix

The comma written at the top of the iteration already represents the hole, so the `i -= 1` re-processing is unnecessary (and is what caused the extra comma). Removing it makes every case round-trip:

| input | before | after |
| --- | --- | --- |
| `[1, , 3]` | `[1,,,3]` (len 4) | `[1,,3]` (len 3) |
| `[1, , ]` | `[1,,,]` (len 3) | `[1,,]` (len 2) |
| `[1, , , 4]` | `[1,,,,4]` (len 5) | `[1,,,4]` (len 4) |
| `[, 'a', , 'b']` | `[,"a",,"b"]` (unchanged) | `[,"a",,"b"]` |

The `Object.assign` path for very sparse arrays returns earlier and is unaffected.

### Tests

Added a round-trip test for sparse arrays whose first hole is not at index 0 (red before the change, green after). Full `npm test` passes (659).