### PR TITLE
fix: round-trip DataView subviews (byteOffset/byteLength)

### DIFF
--- a/.changeset/dataview-subview-roundtrip.md
+++ b/.changeset/dataview-subview-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: round-trip DataView subviews (byteOffset/byteLength)

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -297,8 +297,11 @@ function run(async, value, reducers) {
 
 					// handle subarrays
 					if (typedArray.byteLength !== typedArray.buffer.byteLength) {
-						// to be used with `new TypedArray(buffer, byteOffset, length)`
-						str += `,${typedArray.byteOffset},${typedArray.length}`;
+						// to be used with `new TypedArray(buffer, byteOffset, length)`,
+						// or `new DataView(buffer, byteOffset, byteLength)` — a DataView
+						// has no `length`, so its third argument is its `byteLength`
+						const length = type === 'DataView' ? typedArray.byteLength : typedArray.length;
+						str += `,${typedArray.byteOffset},${length}`;
 					}
 
 					str += ']';

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -318,7 +318,7 @@ export function uneval(value, replacer) {
 
 				// handle subviews
 				if (thing.byteLength !== thing.buffer.byteLength) {
-					str += `,${thing.startOffset},${thing.byteLength}`;
+					str += `,${thing.byteOffset},${thing.byteLength}`;
 				}
 
 				return str + ')';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -312,6 +312,12 @@ const fixtures = {
 			json: '[["DataView",1],["ArrayBuffer","AQID"]]'
 		},
 		{
+			name: 'DataView with byteOffset',
+			value: new DataView(new Uint8Array([1, 2, 3, 4]).buffer, 1, 2),
+			js: 'new DataView(new Uint8Array([1,2,3,4]).buffer,1,2)',
+			json: '[["DataView",1,1,2],["ArrayBuffer","AQIDBA=="]]'
+		},
+		{
 			name: 'URL',
 			value: new URL('https://user:password@example.com/<script>/path?foo=bar#hash'),
 			js: 'new URL("https://user:password@example.com/%3Cscript%3E/path?foo=bar#hash")',


### PR DESCRIPTION
### What

A `DataView` that covers only part of its buffer (created with a `byteOffset`/`byteLength`) does not round-trip:

```js
import { stringify, parse, uneval } from 'devalue';

const view = new DataView(new Uint8Array([1, 2, 3, 4]).buffer, 1, 2);

stringify(view);       // '[["DataView",1,1,undefined],...]'  → parse() throws (invalid JSON)
uneval(view);          // 'new DataView(...,undefined,2)'      → byteOffset lost (becomes 0)
```

A full-buffer `DataView` round-trips fine — the subview branch is only taken when `byteLength !== buffer.byteLength`.

### Why

The subview branch is shared with the typed-array branch and reused their property names:

- **stringify** wrote `typedArray.length`. That is correct for a typed array, but a `DataView` has no `.length` (only `.byteLength`), so the third serialized field was `undefined` — invalid JSON.
- **uneval** wrote `thing.startOffset`, which doesn't exist on a `DataView` (the property is `byteOffset`), so the offset argument came out as `undefined`. (The other `uneval` `DataView` branch, used for referenced values, already used `byteOffset` — so the two were inconsistent.)

`parse` already reconstructs via `new DataView(buffer, value[2], value[3])`, i.e. `(buffer, byteOffset, byteLength)`, so emitting `byteOffset` + `byteLength` is what it expects.

### Fix

- `stringify`: use `byteLength` for a `DataView` (and keep `length` for typed arrays).
- `uneval`: use `byteOffset` instead of the non-existent `startOffset`.

### Tests

Added a `DataView with byteOffset` fixture (covered by the existing uneval/stringify/parse round-trip checks). Full `npm test` passes (664).