### PR TITLE
fix: uneval of a repeated empty Set or Map produces invalid JS

### DIFF
--- a/.changeset/uneval-empty-set-map-reference.md
+++ b/.changeset/uneval-empty-set-map-reference.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: uneval repeated empty Sets and Maps as valid JS

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -415,20 +415,24 @@ export function uneval(value, replacer) {
 
 				case 'Set':
 					values.push(`new Set`);
-					statements.push(
-						`${name}.${Array.from(thing)
-							.map((v) => `add(${stringify(v)})`)
-							.join('.')}`
-					);
+					if (thing.size > 0) {
+						statements.push(
+							`${name}.${Array.from(thing)
+								.map((v) => `add(${stringify(v)})`)
+								.join('.')}`
+						);
+					}
 					break;
 
 				case 'Map':
 					values.push(`new Map`);
-					statements.push(
-						`${name}.${Array.from(thing)
-							.map(([k, v]) => `set(${stringify(k)}, ${stringify(v)})`)
-							.join('.')}`
-					);
+					if (thing.size > 0) {
+						statements.push(
+							`${name}.${Array.from(thing)
+								.map(([k, v]) => `set(${stringify(k)}, ${stringify(v)})`)
+								.join('.')}`
+						);
+					}
 					break;
 
 				case 'Int8Array':

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -625,6 +625,22 @@ const fixtures = {
 		},
 
 		{
+			name: 'empty Set (repetition)',
+			value: ((set) => [set, set])(new Set()),
+			js: '(function(a){return [a,a]}(new Set))',
+			json: '[[1,1],["Set"]]',
+			validate: ([a, b]) => assert.is(a, b)
+		},
+
+		{
+			name: 'empty Map (repetition)',
+			value: ((map) => [map, map])(new Map()),
+			js: '(function(a){return [a,a]}(new Map))',
+			json: '[[1,1],["Map"]]',
+			validate: ([a, b]) => assert.is(a, b)
+		},
+
+		{
 			name: 'RegExp (repetition)',
 			value: ((regexp) => [regexp, regexp])(/regexp/),
 			js: '(function(a){return [a,a]}(new RegExp("regexp")))',


### PR DESCRIPTION
### What

When an empty `Set` or `Map` is referenced more than once, `uneval` emits invalid JavaScript:

```js
import { uneval } from 'devalue';

const set = new Set();
uneval([set, set]);
// '(function(a){a.;return [a,a]}(new Set))'  → SyntaxError: Unexpected token ';'

const map = new Map();
uneval([map, map]);
// '(function(a){a.;return [a,a]}(new Map))'  → SyntaxError
```

A non-empty repeated Set/Map is fine (`a.add(1)`), and `stringify`/`parse` is unaffected — this is specific to `uneval` of an *empty* Set/Map that gets a name in the IIFE preamble.

### Why

A referenced Set/Map is rebuilt with a method chain:

```js
statements.push(`${name}.${Array.from(thing).map((v) => `add(${stringify(v)})`).join('.')}`);
```

For an empty collection, `Array.from(thing)` is `[]`, so `.map(...).join('.')` is `''` and the statement is just `` `${name}.` `` → `a.`. Joined with the other statements by `;`, that becomes `a.;`.

### Fix

Only push the `.add(...)` / `.set(...)` chain when the collection is non-empty; an empty `Set`/`Map` is already fully constructed by `new Set` / `new Map`.

### Tests

Added `empty Set (repetition)` and `empty Map (repetition)` fixtures (the existing repetition tests eval the `uneval` output and assert the two references are identical). Full `npm test` passes (670).