### PR TITLE
fix: uneval loses a repeated typed array/DataView referenced inside a cycle

### DIFF
--- a/.changeset/uneval-reference-ordering.md
+++ b/.changeset/uneval-reference-ordering.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: emit uneval reconstructions before the statements that reference them

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -363,6 +363,13 @@ export function uneval(value, replacer) {
 		/** @type {string[]} */
 		const values = [];
 
+		// Reconstructions (e.g. `b = new Uint8Array(...)`) reassign a placeholder
+		// parameter. They must run before the `statements` that reference them,
+		// otherwise those statements capture the placeholder. They only depend on
+		// IIFE arguments (never on each other), so emitting them first is safe.
+		/** @type {string[]} */
+		const reconstructions = [];
+
 		names.forEach((name, thing) => {
 			params.push(name);
 
@@ -460,7 +467,7 @@ export function uneval(value, replacer) {
 					}
 
 					values.push(`{}`);
-					statements.push(`${name}=${str}`);
+					reconstructions.push(`${name}=${str}`);
 					break;
 				}
 
@@ -481,7 +488,7 @@ export function uneval(value, replacer) {
 					str += ')';
 
 					values.push(`{}`);
-					statements.push(`${name}=${str}`);
+					reconstructions.push(`${name}=${str}`);
 					break;
 				}
 
@@ -499,7 +506,8 @@ export function uneval(value, replacer) {
 
 		statements.push(`return ${str}`);
 
-		return `(function(${params.join(',')}){${statements.join(';')}}(${values.join(',')}))`;
+		const body = [...reconstructions, ...statements].join(';');
+		return `(function(${params.join(',')}){${body}}(${values.join(',')}))`;
 	} else {
 		return str;
 	}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1350,6 +1350,19 @@ uvu.test('does not create duplicate parameter names', () => {
 	eval(serialized);
 });
 
+uvu.test('reconstructs a referenced typed array before it is used in a cycle', () => {
+	const view = new Uint8Array([1, 2, 3]);
+	const obj = { a: view, b: view };
+	obj.self = obj;
+
+	const result = (0, eval)(uneval(obj));
+
+	assert.is(result.self, result);
+	assert.ok(result.a instanceof Uint8Array);
+	assert.is(result.a, result.b);
+	assert.equal(Array.from(result.a), [1, 2, 3]);
+});
+
 uvu.test('rejects sparse array __proto__ pollution via parse', () => {
 	// Attempt to set __proto__ on an array via the sparse array encoding
 	const payload = JSON.stringify([[consts.SPARSE, 1, '__proto__', { polluted: true }]]);


### PR DESCRIPTION
### What

A typed array / `DataView` / `ArrayBuffer` that is referenced more than once and lives inside a **cyclic** container is lost on round-trip — references to it become the `{}` placeholder:

```js
import { uneval } from 'devalue';

const view = new Uint8Array([1, 2, 3]);
const obj = { a: view, b: view };
obj.self = obj; // make `obj` a named, cyclic value

uneval(obj);
// (function(a,b){a.self=a;a.a=b;a.b=b;b=new Uint8Array([1,2,3]);return a}({},{}))
//                          ^^^^^^^^ a.a / a.b captured the {} placeholder

const back = eval(`(${uneval(obj)})`);
back.a; // {}  — should be Uint8Array [1, 2, 3]
```

(`[view, view]` is fine — the references are in the `return`, after the reassignment. The bug needs a container whose fills run *before* the reassignment, i.e. a cyclic/named container.)

### Why

A repeated typed array / DataView / ArrayBuffer is hoisted as a placeholder (`{}`) and rebuilt with a reassignment (`b = new Uint8Array(...)`). That reassignment was pushed onto the **same ordered `statements` list** as the property fills (`a.a = b`). The list is ordered by reference count, so when a referencing container is emitted first, `a.a = b` runs while `b` is still `{}`.

### Fix

Emit those reassignments first, in a separate `reconstructions` list. They only depend on IIFE arguments — a typed array's buffer is always passed as an argument and never reassigned — so they never depend on each other or on the containers. Running them before the property fills makes every reference resolve to the real value.

I verified with a round-trip fuzzer (`uneval(eval(uneval(v))) === uneval(v)` over 20k random values mixing cycles, repeated references, typed arrays, DataViews and sparse arrays): this was the last remaining `uneval` round-trip failure in that space.

### Tests

Added a test that round-trips a typed array referenced twice inside a cycle (red before, green after). Full `npm test` passes (659).