### PR TITLE
fix: preserve shared-reference identity for Map keys in uneval

### DIFF
--- a/.changeset/uneval-map-key-dedupe.md
+++ b/.changeset/uneval-map-key-dedupe.md
@@ -1,0 +1,5 @@
+---
+'devalue': patch
+---
+
+fix: preserve shared-reference identity for Map keys in `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -79,6 +79,7 @@ export function uneval(value, replacer) {
 				case 'Map':
 					for (const [key, value] of thing) {
 						keys.push(`.get(${is_primitive(key) ? stringify_primitive(key) : '...'})`);
+						walk(key);
 						walk(value);
 						keys.pop();
 					}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -727,6 +727,7 @@ const fixtures = {
 			js: '(function(a,b){a=new DataView(b);return [a,a,b]}({},new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer))',
 			json: '[[1,1,2],["DataView",2],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
 		},
+
 		{
 			name: 'DataView subview (repetition)',
 			value: (() => {
@@ -748,6 +749,62 @@ const fixtures = {
 			validate: ([a, b]) => {
 				assert.is(a, b);
 				assert.ok(a instanceof Temporal.Instant);
+			}
+		},
+
+		{
+			name: 'Map key (repetition)',
+			value: (() => {
+				const shared = { id: 1 };
+				return [shared, new Map([[shared, 'v']])];
+			})(),
+			js: '(function(a){a.id=1;return [a,new Map([[a,"v"]])]}({}))',
+			json: '[[1,3],{"id":2},1,["Map",1,4],"v"]',
+			validate: ([obj, map]) => assert.is([...map.keys()][0], obj)
+		},
+
+		{
+			name: 'Map keys (interlinked)',
+			value: (() => {
+				const node1 = { id: 1 };
+				const node2 = { id: 2 };
+				const node3 = { id: 3 };
+				return new Map([
+					[
+						node1,
+						new Map([
+							[node2, 1],
+							[node3, 1]
+						])
+					],
+					[
+						node2,
+						new Map([
+							[node1, 1],
+							[node3, 1]
+						])
+					],
+					[
+						node3,
+						new Map([
+							[node1, 1],
+							[node2, 1]
+						])
+					]
+				]);
+			})(),
+			js: '(function(a,b,c){a.id=1;b.id=2;c.id=3;return new Map([[a,new Map([[b,1],[c,1]])],[b,new Map([[a,1],[c,1]])],[c,new Map([[a,1],[b,1]])]])}({},{},{}))',
+			json: '[["Map",1,3,4,8,6,9],{"id":2},1,["Map",4,2,6,2],{"id":5},2,{"id":7},3,["Map",1,2,6,2],["Map",1,2,4,2]]',
+			validate: (map) => {
+				const [node1, node2, node3] = [...map.keys()];
+				// each node appears as a key in the two sibling sub-maps;
+				// the same object identity must be preserved everywhere
+				assert.is([...map.get(node2).keys()][0], node1);
+				assert.is([...map.get(node3).keys()][0], node1);
+				assert.is([...map.get(node1).keys()][0], node2);
+				assert.is([...map.get(node3).keys()][1], node2);
+				assert.is([...map.get(node1).keys()][1], node3);
+				assert.is([...map.get(node2).keys()][1], node3);
 			}
 		}
 	],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -796,15 +796,19 @@ const fixtures = {
 			js: '(function(a,b,c){a.id=1;b.id=2;c.id=3;return new Map([[a,new Map([[b,1],[c,1]])],[b,new Map([[a,1],[c,1]])],[c,new Map([[a,1],[b,1]])]])}({},{},{}))',
 			json: '[["Map",1,3,4,8,6,9],{"id":2},1,["Map",4,2,6,2],{"id":5},2,{"id":7},3,["Map",1,2,6,2],["Map",1,2,4,2]]',
 			validate: (map) => {
-				const [node1, node2, node3] = [...map.keys()];
+				const [node1, node2, node3] = map.keys();
+				const from1 = [...map.get(node1).keys()];
+				const from2 = [...map.get(node2).keys()];
+				const from3 = [...map.get(node3).keys()];
+
 				// each node appears as a key in the two sibling sub-maps;
 				// the same object identity must be preserved everywhere
-				assert.is([...map.get(node2).keys()][0], node1);
-				assert.is([...map.get(node3).keys()][0], node1);
-				assert.is([...map.get(node1).keys()][0], node2);
-				assert.is([...map.get(node3).keys()][1], node2);
-				assert.is([...map.get(node1).keys()][1], node3);
-				assert.is([...map.get(node2).keys()][1], node3);
+				assert.is(from2[0], node1);
+				assert.is(from3[0], node1);
+				assert.is(from1[0], node2);
+				assert.is(from3[1], node2);
+				assert.is(from1[1], node3);
+				assert.is(from2[1], node3);
 			}
 		}
 	],


### PR DESCRIPTION
### What

`uneval` does not deduplicate objects used as **`Map` keys**. When the same object is a key in more than one `Map` (or is a `Map` key and also appears elsewhere in the graph), `uneval` inlines a fresh copy at each occurrence, so the round-tripped value loses object identity:

```js
import { uneval } from 'devalue';

const node1 = { id: 1 };
const node2 = { id: 2 };
const node3 = { id: 3 };

const map = new Map([
  [node1, new Map([[node2, 1], [node3, 1]])],
  [node2, new Map([[node1, 1], [node3, 1]])],
  [node3, new Map([[node1, 1], [node2, 1]])]
]);

uneval(map);
// before:
// new Map([[{id:1},new Map([[{id:2},1],[{id:3},1]])], ...])
//   → eval'd result has three *distinct* {id:1} objects,
//     so map's keys are no longer === the keys used inside the sub-maps
```

`stringify` / `parse` already handle this correctly — only `uneval` is affected. Closes #54.

### Why

In the `walk` pass, the `Map` case only recursed into values, not keys:

```js
case 'Map':
  for (const [key, value] of thing) {
    keys.push(...);
    walk(value);   // key was never walked
    keys.pop();
  }
```

Because keys never entered `counts`, a key that appears more than once was never recognized as a shared reference and never assigned a hoisted variable — so each occurrence was serialized inline as a fresh literal. (`Set` already walks its members, and `stringify`'s flatten pass already walks both `flatten(key)` and `flatten(value)`, which is why those paths were unaffected.)

### Fix

Walk the key as well as the value. The existing `stringify` step already emits the hoisted name for any value that ended up in `names`, including keys reached through the `Map` entry arrays, so no other change is needed:

```js
case 'Map':
  for (const [key, value] of thing) {
    keys.push(...);
    walk(key);
    walk(value);
    keys.pop();
  }
```

After the fix:

```js
uneval(map);
// (function(a,b,c){a.id=1;b.id=2;c.id=3;return new Map([
//   [a,new Map([[b,1],[c,1]])],
//   [b,new Map([[a,1],[c,1]])],
//   [c,new Map([[a,1],[b,1]])]
// ])}({},{},{}))
//   → identity preserved across all sub-maps
```

### Tests

Added two `repetition` fixtures (each exercised by the existing uneval / stringify / parse / unflatten / stringifyAsync round-trip suites, with `validate` callbacks asserting key identity):

- **Map key (repetition)** — minimal case: an object shared as a `Map` key and a sibling array element.
- **Map keys (interlinked)** — the issue #54 graph above.

Both new `uneval` fixtures fail on `main` and pass with this change; the `stringify`/`parse` variants pass either way (confirming the bug was `uneval`-only). Full suite: 692 passing.