### PR TITLE
fix: serialize Temporal values referenced more than once in uneval

### DIFF
--- a/.changeset/temporal-uneval-reference.md
+++ b/.changeset/temporal-uneval-reference.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: serialize Temporal values referenced more than once in `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -489,6 +489,17 @@ export function uneval(value, replacer) {
 					values.push(`new Uint8Array([${new Uint8Array(thing)}]).buffer`);
 					break;
 
+				case 'Temporal.Duration':
+				case 'Temporal.Instant':
+				case 'Temporal.PlainDate':
+				case 'Temporal.PlainTime':
+				case 'Temporal.PlainDateTime':
+				case 'Temporal.PlainMonthDay':
+				case 'Temporal.PlainYearMonth':
+				case 'Temporal.ZonedDateTime':
+					values.push(`${type}.from(${stringify_string(thing.toString())})`);
+					break;
+
 				default:
 					values.push(Object.getPrototypeOf(thing) === null ? 'Object.create(null)' : '{}');
 					Object.keys(thing).forEach((key) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -736,6 +736,19 @@ const fixtures = {
 			})(),
 			js: '(function(a){a=new DataView(new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer,2,4);return [a,a]}({}))',
 			json: '[[1,1],["DataView",2,2,4],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
+		},
+
+		{
+			name: 'Temporal.Instant (repetition)',
+			value: ((instant) => [instant, instant])(
+				Temporal.Instant.from('1999-09-29T05:30:00Z')
+			),
+			js: '(function(a){return [a,a]}(Temporal.Instant.from("1999-09-29T05:30:00Z")))',
+			json: '[[1,1],["Temporal.Instant","1999-09-29T05:30:00Z"]]',
+			validate: ([a, b]) => {
+				assert.is(a, b);
+				assert.ok(a instanceof Temporal.Instant);
+			}
 		}
 	],
 


### PR DESCRIPTION
`uneval` has two code paths: an inline value format, and a reference format used when a value appears more than once or inside a cycle (the value is hoisted into a function parameter so the references can share identity).

The inline format handles the eight `Temporal.*` types, but the reference format never got a matching case, so a repeated Temporal value falls through to the plain-object branch and is emitted as `{}`. It is silently lost:

```js
const instant = Temporal.Instant.from('1999-09-29T05:30:00Z');

uneval([instant, instant]);
// before: (function(a){return [a,a]}({}))
// after:  (function(a){return [a,a]}(Temporal.Instant.from("1999-09-29T05:30:00Z")))
```

`stringify` round-trips the same input correctly (`[[1,1],["Temporal.Instant","1999-09-29T05:30:00Z"]]`), so the two serializers disagreed on a repeated Temporal value.

This mirrors the existing inline Temporal case into the reference switch and adds a repetition fixture. Reverting only the `uneval.js` change fails the new `uneval: repetition` case while the `stringify`/`parse`/`unflatten` checks stay green, which isolates the bug to `uneval`.
