### PR TITLE
fix: serialize DataView subviews with correct byte offset and length

### DIFF
--- a/.changeset/dataview-subview.md
+++ b/.changeset/dataview-subview.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: serialize DataView subviews with the correct byte offset and length

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -289,16 +289,27 @@ function run(async, value, reducers) {
 				case 'Float32Array':
 				case 'Float64Array':
 				case 'BigInt64Array':
-				case 'BigUint64Array':
-				case 'DataView': {
+				case 'BigUint64Array': {
 					/** @type {import("./types.js").TypedArray} */
 					const typedArray = thing;
 					str = '["' + type + '",' + flatten(typedArray.buffer);
 
 					// handle subarrays
 					if (typedArray.byteLength !== typedArray.buffer.byteLength) {
-						// to be used with `new TypedArray(buffer, byteOffset, length)`
 						str += `,${typedArray.byteOffset},${typedArray.length}`;
+					}
+
+					str += ']';
+					break;
+				}
+
+				case 'DataView': {
+					/** @type {DataView} */
+					const view = thing;
+					str = '["' + type + '",' + flatten(view.buffer);
+
+					if (view.byteLength !== view.buffer.byteLength) {
+						str += `,${view.byteOffset},${view.byteLength}`;
 					}
 
 					str += ']';

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -318,7 +318,7 @@ export function uneval(value, replacer) {
 
 				// handle subviews
 				if (thing.byteLength !== thing.buffer.byteLength) {
-					str += `,${thing.startOffset},${thing.byteLength}`;
+					str += `,${thing.byteOffset},${thing.byteLength}`;
 				}
 
 				return str + ')';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -312,6 +312,12 @@ const fixtures = {
 			json: '[["DataView",1],["ArrayBuffer","AQID"]]'
 		},
 		{
+			name: 'DataView subview',
+			value: new DataView(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer, 2, 4),
+			js: 'new DataView(new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer,2,4)',
+			json: '[["DataView",1,2,4],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
+		},
+		{
 			name: 'URL',
 			value: new URL('https://user:password@example.com/<script>/path?foo=bar#hash'),
 			js: 'new URL("https://user:password@example.com/%3Cscript%3E/path?foo=bar#hash")',
@@ -698,6 +704,16 @@ const fixtures = {
 			})(),
 			js: '(function(a,b){a=new DataView(b);return [a,a,b]}({},new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer))',
 			json: '[[1,1,2],["DataView",2],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
+		},
+		{
+			name: 'DataView subview (repetition)',
+			value: (() => {
+				const uint8 = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+				const dv = new DataView(uint8.buffer, 2, 4);
+				return [dv, dv];
+			})(),
+			js: '(function(a){a=new DataView(new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer,2,4);return [a,a]}({}))',
+			json: '[[1,1],["DataView",2,2,4],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
 		}
 	],
 


### PR DESCRIPTION
## Problem

Serializing a `DataView` that is a *subview* of its buffer (created with `new DataView(buffer, byteOffset, byteLength)`) produced incorrect output in two separate code paths:

- **`uneval`** referenced `thing.startOffset` — a property that does not exist on `DataView`. It evaluates to `undefined`, so the output was `new DataView(..., undefined, 4)`. On revival, `undefined` coerces to `0`, silently placing the view at the **wrong offset** with no error.
- **`stringify`** reused the shared typed-array branch and emitted `typedArray.length`. `DataView` has no `.length` property, so the output was `["DataView", 1, 2, undefined]` — **invalid JSON** that throws on `parse`.

Full-buffer DataViews were unaffected (the offset/length arguments are only emitted for subviews), which is why this went unnoticed.

## Fix

Both paths now emit `byteOffset, byteLength`, matching the `new DataView(buffer, byteOffset, byteLength)` constructor signature. In `stringify`, the shared typed-array/DataView branch now selects `byteLength` for DataViews (a byte count) and `length` for typed arrays (an element count).

## Tests

Adds regression fixtures for both an inline and a named (deduplicated) DataView subview. Verified that each fixture fails against the unfixed code for the right reason:

- Reverting the `uneval` fix → `uneval: basics "DataView subview"` fails with `...,undefined,4)` vs expected `...,2,4)`.
- Reverting the `stringify` fix → 6 fixtures across `stringify` / `stringifyAsync` / `stringifyAsync round-trip` fail with `["DataView",1,2,undefined]` vs expected `["DataView",1,2,4]`.

With both fixes in place, the full suite passes.
