### PR TITLE
fix: uneval emits valid JS for repeated empty Map/Set

### DIFF
--- a/.changeset/fix-empty-map-set-uneval.md
+++ b/.changeset/fix-empty-map-set-uneval.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: `uneval` now produces valid output for a repeated empty `Map` or `Set`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -415,19 +415,19 @@ export function uneval(value, replacer) {
 
 				case 'Set': {
 					values.push(`new Set`);
-					const adds = Array.from(thing).map((v) => `add(${stringify(v)})`);
+					const adds = Array.from(thing).map((v) => `.add(${stringify(v)})`);
 					// An empty Set is fully built by `new Set`; a chained statement would
 					// otherwise be a dangling `name.`.
-					if (adds.length > 0) statements.push(`${name}.${adds.join('.')}`);
+					if (adds.length > 0) statements.push(name + adds.join(''));
 					break;
 				}
 
 				case 'Map': {
 					values.push(`new Map`);
 					const sets = Array.from(thing).map(
-						([k, v]) => `set(${stringify(k)}, ${stringify(v)})`
+						([k, v]) => `.set(${stringify(k)}, ${stringify(v)})`
 					);
-					if (sets.length > 0) statements.push(`${name}.${sets.join('.')}`);
+					if (sets.length > 0) statements.push(name + sets.join(''));
 					break;
 				}
 

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -413,23 +413,23 @@ export function uneval(value, replacer) {
 					});
 					break;
 
-				case 'Set':
+				case 'Set': {
 					values.push(`new Set`);
-					statements.push(
-						`${name}.${Array.from(thing)
-							.map((v) => `add(${stringify(v)})`)
-							.join('.')}`
-					);
+					const adds = Array.from(thing).map((v) => `add(${stringify(v)})`);
+					// An empty Set is fully built by `new Set`; a chained statement would
+					// otherwise be a dangling `name.`.
+					if (adds.length > 0) statements.push(`${name}.${adds.join('.')}`);
 					break;
+				}
 
-				case 'Map':
+				case 'Map': {
 					values.push(`new Map`);
-					statements.push(
-						`${name}.${Array.from(thing)
-							.map(([k, v]) => `set(${stringify(k)}, ${stringify(v)})`)
-							.join('.')}`
+					const sets = Array.from(thing).map(
+						([k, v]) => `set(${stringify(k)}, ${stringify(v)})`
 					);
+					if (sets.length > 0) statements.push(`${name}.${sets.join('.')}`);
 					break;
+				}
 
 				case 'Int8Array':
 				case 'Uint8Array':

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -631,6 +631,28 @@ const fixtures = {
 		},
 
 		{
+			name: 'empty Map (repetition)',
+			value: ((map) => [map, map])(new Map()),
+			js: '(function(a){return [a,a]}(new Map))',
+			json: '[[1,1],["Map"]]',
+			validate: ([a, b]) => {
+				assert.is(a, b);
+				assert.is(a.size, 0);
+			}
+		},
+
+		{
+			name: 'empty Set (repetition)',
+			value: ((set) => [set, set])(new Set()),
+			js: '(function(a){return [a,a]}(new Set))',
+			json: '[[1,1],["Set"]]',
+			validate: ([a, b]) => {
+				assert.is(a, b);
+				assert.is(a.size, 0);
+			}
+		},
+
+		{
 			name: 'RegExp (repetition)',
 			value: ((regexp) => [regexp, regexp])(/regexp/),
 			js: '(function(a){return [a,a]}(new RegExp("regexp")))',


### PR DESCRIPTION
## Problem

When a `Map` or `Set` is referenced more than once, `uneval` binds it to a variable and populates it via a chained statement:

```js
uneval([map, map])
// (function(a){a.set("k","v").set(...);return [a,a]}(new Map))
```

But when the collection is **empty**, the chain is empty, producing a dangling member expression that is a **syntax error**:

```js
uneval([new Map(), new Map()])
// (function(a){a.;return [a,a]}(new Map))   <- `a.` is invalid
```

## Fix

Emit no chained statement for an empty `Map`/`Set` — `new Map`/`new Set` already fully constructs it. After the fix:

```js
uneval([new Map(), new Map()])
// (function(a){return [a,a]}(new Map))
```

## Tests

Adds `empty Map (repetition)` and `empty Set (repetition)` fixtures, which exercise `uneval`, `stringify`, and their round-trips. Full suite passes (692 tests).

Includes a patch changeset.