### PR TITLE
fix: reconstruct typed arrays and DataViews before referencing statements in uneval

### DIFF
--- a/.changeset/uneval-reconstruction-ordering.md
+++ b/.changeset/uneval-reconstruction-ordering.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: reconstruct typed arrays and DataViews before the statements that reference them in `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -459,7 +459,10 @@ export function uneval(value, replacer) {
 					}
 
 					values.push(`{}`);
-					statements.push(`${name}=${str}`);
+					// Reconstructions reassign the placeholder param and depend only on
+					// IIFE arguments, never on other statements. They must run before the
+					// mutations that reference the param, so emit them at the front.
+					statements.unshift(`${name}=${str}`);
 					break;
 				}
 
@@ -480,7 +483,8 @@ export function uneval(value, replacer) {
 					str += ')';
 
 					values.push(`{}`);
-					statements.push(`${name}=${str}`);
+					// See the typed-array case above: reconstructions must run first.
+					statements.unshift(`${name}=${str}`);
 					break;
 				}
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1473,6 +1473,33 @@ uvu.test('does not create duplicate parameter names', () => {
 	eval(serialized);
 });
 
+uvu.test('reconstructs a referenced typed array before it is used in a cycle', () => {
+	const view = new Uint8Array([1, 2, 3]);
+	const obj = { a: view, b: view };
+	obj.self = obj;
+
+	const result = (0, eval)(uneval(obj));
+
+	assert.is(result.self, result);
+	assert.ok(result.a instanceof Uint8Array);
+	assert.is(result.a, result.b);
+	assert.equal(Array.from(result.a), [1, 2, 3]);
+});
+
+uvu.test('reconstructs a referenced DataView before it is used in a cycle', () => {
+	const view = new DataView(new Uint8Array([1, 2, 3, 4]).buffer, 1, 2);
+	const obj = { a: view, b: view };
+	obj.self = obj;
+
+	const result = (0, eval)(uneval(obj));
+
+	assert.is(result.self, result);
+	assert.ok(result.a instanceof DataView);
+	assert.is(result.a, result.b);
+	assert.is(result.a.byteLength, 2);
+	assert.equal(Array.from(new Uint8Array(result.a.buffer, result.a.byteOffset, 2)), [2, 3]);
+});
+
 uvu.test('rejects sparse array __proto__ pollution via parse', () => {
 	// Attempt to set __proto__ on an array via the sparse array encoding
 	const payload = JSON.stringify([[consts.SPARSE, 1, '__proto__', { polluted: true }]]);


### PR DESCRIPTION
Alternative to #163; will let @Rich-Harris decide which one is better.

## Problem

A typed array or `DataView` that is referenced more than once is hoisted into an IIFE parameter. When its buffer is *also* hoisted (a separate param), the view can't be built in the argument list, because arguments are evaluated before the params are bound. So `uneval` passes a placeholder `{}` as the argument and *reassigns* the param to the real value inside the body — a **reconstruction**, e.g. `b=new Uint8Array(a)`.

The bug: mutation statements that reference the param (typically from a cycle) could be emitted **before** the reconstruction, capturing the placeholder `{}` instead of the real typed array.

### Reproduction (on `main`)

```js
const view = new Uint8Array([1, 2, 3]);
const obj = { a: view, b: view };
obj.self = obj;

(0, eval)('(' + uneval(obj) + ')');
```

produces

```js
(function(a,b){a.a=b;a.b=b;a.self=a;b=new Uint8Array([1,2,3]);return a}({},{}))
```

`a.a=b` runs while `b` is still `{}`, so `result.a` is a plain object, not a `Uint8Array`, and its contents are lost.

## Fix

Emit reconstructions at the **front** of the IIFE body (`unshift` instead of `push`) so they run before any mutation statement.

This is always safe: a reconstruction depends only on IIFE **arguments** — specifically its buffer. An `ArrayBuffer` is a flat block of bytes that can't contain object references, so it's always serialized as an argument-only leaf (`values.push(...)`, never a statement). A reconstruction therefore can never depend on another statement or on another reconstruction, so moving them to the front cannot break any dependency.

## Tests

Adds regression tests for a shared typed array and a shared `DataView`, each inside a cycle. Also validated with an out-of-tree fuzzer (500k randomized nested/aliased/cyclic structures across all supported types) which fails on `main` and passes with this change.

Closes #163.