### PR TITLE
fix: emit valid JS for BigInt64Array and BigUint64Array in uneval

### DIFF
--- a/.changeset/uneval-bigint-typed-array.md
+++ b/.changeset/uneval-bigint-typed-array.md
@@ -1,0 +1,5 @@
+---
+"devalue": patch
+---
+
+fix: emit valid JS for `BigInt64Array` and `BigUint64Array` in `uneval`

--- a/src/uneval.js
+++ b/src/uneval.js
@@ -290,8 +290,7 @@ export function uneval(value, replacer) {
 				let str = `new ${type}`;
 
 				if (!names.has(thing.buffer)) {
-					const array = new thing.constructor(thing.buffer);
-					str += `([${array}])`;
+					str += `([${stringify_typed_array_elements(new thing.constructor(thing.buffer))}])`;
 				} else {
 					str += `(${stringify(thing.buffer)})`;
 				}
@@ -445,8 +444,7 @@ export function uneval(value, replacer) {
 					let str = `new ${type}`;
 
 					if (!names.has(thing.buffer)) {
-						const array = new thing.constructor(thing.buffer);
-						str += `([${array}])`;
+						str += `([${stringify_typed_array_elements(new thing.constructor(thing.buffer))}])`;
 					} else {
 						str += `(${stringify(thing.buffer)})`;
 					}
@@ -513,6 +511,20 @@ export function uneval(value, replacer) {
 	} else {
 		return str;
 	}
+}
+
+/**
+ * Serialize the elements of a typed array as a comma-separated list.
+ * `BigInt64Array`/`BigUint64Array` elements are bigints and must be written
+ * with an `n` suffix, otherwise the emitted `new BigInt64Array([...])` throws.
+ * @param {import('./types.js').TypedArray} array
+ */
+function stringify_typed_array_elements(array) {
+	if (array instanceof BigInt64Array || array instanceof BigUint64Array) {
+		return Array.from(array, (element) => `${element}n`).join(',');
+	}
+
+	return array.toString();
 }
 
 /** @param {number} num */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -300,6 +300,18 @@ const fixtures = {
 			json: '[["Uint8Array",1],["ArrayBuffer","AQID"]]'
 		},
 		{
+			name: 'BigInt64Array',
+			value: new BigInt64Array([1n, -2n, 3n]),
+			js: 'new BigInt64Array([1n,-2n,3n])',
+			json: '[["BigInt64Array",1],["ArrayBuffer","AQAAAAAAAAD+/////////wMAAAAAAAAA"]]'
+		},
+		{
+			name: 'BigUint64Array',
+			value: new BigUint64Array([1n, 2n, 3n]),
+			js: 'new BigUint64Array([1n,2n,3n])',
+			json: '[["BigUint64Array",1],["ArrayBuffer","AQAAAAAAAAACAAAAAAAAAAMAAAAAAAAA"]]'
+		},
+		{
 			name: 'ArrayBuffer',
 			value: new Uint8Array([1, 2, 3]).buffer,
 			js: 'new Uint8Array([1,2,3]).buffer',
@@ -737,6 +749,14 @@ const fixtures = {
 			})(),
 			js: '(function(a){a=new DataView(new Uint8Array([0,1,2,3,4,5,6,7,8,9]).buffer,2,4);return [a,a]}({}))',
 			json: '[[1,1],["DataView",2,2,4],["ArrayBuffer","AAECAwQFBgcICQ=="]]'
+		},
+
+		{
+			name: 'BigInt64Array (repetition)',
+			value: ((array) => [array, array])(new BigInt64Array([1n, 2n, 3n])),
+			js: '(function(a){a=new BigInt64Array([1n,2n,3n]);return [a,a]}({}))',
+			json: '[[1,1],["BigInt64Array",2],["ArrayBuffer","AQAAAAAAAAACAAAAAAAAAAMAAAAAAAAA"]]',
+			validate: ([a, b]) => assert.is(a, b)
 		},
 
 		{


### PR DESCRIPTION
## Problem

`uneval` renders typed-array elements by interpolating the array directly into a template string, which invokes `Array#toString` and produces bare numbers:

```js
uneval(new BigInt64Array([1n, 2n, 3n]))
// → 'new BigInt64Array([1,2,3])'
```

But the `BigInt64Array`/`BigUint64Array` constructors require **bigint** elements, so the emitted code throws when evaluated:

```
Cannot convert 1 to a BigInt
```

This affects any `BigInt64Array`/`BigUint64Array` whose buffer isn't separately shared (the common case), including subarrays. There was previously no test coverage for these two types.

## Fix

Emit bigint elements with an `n` suffix (e.g. `new BigInt64Array([1n,2n,3n])`) via a small `stringify_typed_array_elements` helper used by both the inline and the deduplicated (hoisted) code paths. Non-bigint typed arrays are unchanged.

## Scope

- `stringify`/`parse` were **not** affected — they encode the underlying `ArrayBuffer` as base64 and rebuild the view from bytes, so elements are never stringified individually.
- The `uneval` shared-buffer path was also already correct (it reconstructs from the buffer); only the inline-elements path was broken.

## Tests

Adds fixtures for `BigInt64Array` (with a negative value) and `BigUint64Array`, plus a repetition fixture, which run through the existing `uneval` / `stringify` / `parse` / round-trip harnesses.