### PR TITLE
feat: pluggable operations for stringify

### DIFF
--- a/.changeset/pluggable-stringify-operations.md
+++ b/.changeset/pluggable-stringify-operations.md
@@ -1,0 +1,5 @@
+---
+'devalue': minor
+---
+
+feat: add pluggable `operations` option to `stringify`/`stringifyAsync`. Every introspection performed on the value being serialized (property reads, prototype method calls, iteration, type classification) now routes through an overridable `StringifyOperations` interface, enabling side-effect-free serialization (no getters, proxy traps, or patched prototype methods) and serialization of values in foreign runtimes via handles. Defaults are exported as `defaultOperations` and preserve existing behavior exactly.

--- a/.changeset/pluggable-stringify-operations.md
+++ b/.changeset/pluggable-stringify-operations.md
@@ -2,4 +2,4 @@
 'devalue': minor
 ---
 
-feat: add pluggable `operations` option to `stringify`/`stringifyAsync`. Every introspection performed on the value being serialized (property reads, prototype method calls, iteration, type classification) now routes through an overridable `StringifyOperations` interface, enabling side-effect-free serialization (no getters, proxy traps, or patched prototype methods) and serialization of values in foreign runtimes via handles. Defaults are exported as `defaultOperations` and preserve existing behavior exactly.
+feat: add pluggable `operations` option to `stringify`/`stringifyAsync`, allowing customization of how values are introspected during serialization (e.g. side-effect-free or foreign-runtime serialization)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,47 @@ devalue.uneval(vector, (value, uneval) => {
 
 Note that any variables referenced in the resulting JavaScript (like `Vector` in the example above) must be in scope when it runs.
 
+## Custom operations
+
+Every introspection `stringify` performs on the value being serialized — property reads, prototype method calls, iteration, type classification — goes through an operations interface that you can override via the `operations` option. Omitted members fall back to the defaults (exported as `defaultOperations`), which behave exactly as devalue always has.
+
+This is useful in two situations:
+
+**Side-effect-free serialization.** By default, serializing a value can execute user code: getters and proxy traps fire during property reads, `Object.prototype.toString` consults (potentially getter-defined) `Symbol.toStringTag`, and patched prototype methods like `Date.prototype.toISOString` or `Map.prototype[Symbol.iterator]` are invoked. Deterministic or sandboxed runtimes can replace these operations with implementations based on captured intrinsics and property descriptors:
+
+```js
+const originalToISOString = Date.prototype.toISOString;
+
+const stringified = devalue.stringify(value, undefined, {
+	operations: {
+		// use a captured intrinsic instead of a (possibly patched) prototype method
+		dateISO: (date) => originalToISOString.call(date),
+
+		// read through descriptors so getters are never invoked
+		get: (object, key) => {
+			const descriptor = Object.getOwnPropertyDescriptor(object, key);
+			if (descriptor?.get) throw new Error(`refusing to invoke getter for "${key}"`);
+			return descriptor?.value;
+		}
+	}
+});
+```
+
+**Foreign-runtime serialization.** The `stringify` algorithm never touches the value directly, so "value" can be an opaque handle to something living in another JavaScript runtime — a `node:vm` context, a WASM-hosted engine, a remote process — as long as the operations know how to inspect it. Implement `typeOf`/`tag` for classification, `primitive`/`get`/`mapEntries`/etc. for extraction, and `identify` to key deduplication and cycle detection on the underlying value's identity rather than the handle's:
+
+```js
+const stringified = devalue.stringify(rootHandle, undefined, {
+	operations: {
+		identify: (handle) => handle.pointer,
+		typeOf: (handle) => handle.typeOf(),
+		get: (handle, key) => handle.getProperty(key)
+		// ... see StringifyOperations for the full interface
+	}
+});
+```
+
+Reducers compose with custom operations: they receive the raw value/handle, and whatever they return is serialized through the same operations.
+
 ## Error handling
 
 If `uneval` or `stringify` encounters a function or a non-POJO that isn't handled by a custom replacer/reducer, it will throw an error. You can find where in the input data the offending value lives by inspecting `error.path`:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ const originalToISOString = Date.prototype.toISOString;
 const stringified = devalue.stringify(value, undefined, {
 	operations: {
 		// use a captured intrinsic instead of a (possibly patched) prototype method
-		dateISO: (date) => originalToISOString.call(date),
+		toISOString: (date) => originalToISOString.call(date),
 
 		// read through descriptors so getters are never invoked
 		get: (object, key) => {
@@ -171,7 +171,7 @@ const stringified = devalue.stringify(value, undefined, {
 });
 ```
 
-**Foreign-runtime serialization.** The `stringify` algorithm never touches the value directly, so "value" can be an opaque handle to something living in another JavaScript runtime — a `node:vm` context, a WASM-hosted engine, a remote process — as long as the operations know how to inspect it. Implement `typeOf`/`tag` for classification, `primitive`/`get`/`mapEntries`/etc. for extraction, and `identify` to key deduplication and cycle detection on the underlying value's identity rather than the handle's:
+**Foreign-runtime serialization.** The `stringify` algorithm never touches the value directly, so "value" can be an opaque handle to something living in another JavaScript runtime — a `node:vm` context, a WASM-hosted engine, a remote process — as long as the operations know how to inspect it. Implement `typeOf`/`tagOf` for classification, `toPrimitive`/`get`/`entriesOf`/etc. for extraction, and `identify` to key deduplication and cycle detection on the underlying value's identity rather than the handle's:
 
 ```js
 const stringified = devalue.stringify(rootHandle, undefined, {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { uneval } from './src/uneval.js';
 export { parse, unflatten } from './src/parse.js';
 export { stringify, stringifyAsync } from './src/stringify.js';
+export { default_operations as defaultOperations } from './src/operations.js';
 export { DevalueError } from './src/utils.js';

--- a/index.js
+++ b/index.js
@@ -3,3 +3,6 @@ export { parse, unflatten } from './src/parse.js';
 export { stringify, stringifyAsync } from './src/stringify.js';
 export { default_operations as defaultOperations } from './src/operations.js';
 export { DevalueError } from './src/utils.js';
+
+/** @typedef {import('./src/types.js').StringifyOperations} StringifyOperations */
+/** @typedef {import('./src/types.js').StringifyOptions} StringifyOptions */

--- a/src/operations.js
+++ b/src/operations.js
@@ -1,0 +1,79 @@
+import {
+	enumerable_symbols,
+	get_type,
+	is_plain_object,
+	valid_array_indices
+} from './utils.js';
+
+/** @type {{ kind: 'not-plain' }} */
+const NOT_PLAIN = { kind: 'not-plain' };
+
+/** @type {{ kind: 'symbol-keys' }} */
+const SYMBOL_KEYS = { kind: 'symbol-keys' };
+
+/**
+ * The default implementations of every introspection/extraction operation
+ * `stringify` performs on the value being serialized. Each one matches the
+ * behavior devalue has always had (native property access, iteration, etc).
+ *
+ * Pass overrides via the `operations` option of `stringify`/`stringifyAsync`
+ * to customize how values are inspected — e.g. to serialize values without
+ * triggering getters, proxy traps, or patched prototype methods, or to
+ * serialize values that live in a different JavaScript runtime (a `node:vm`
+ * context, a WASM-hosted engine, a remote process) through handle objects.
+ *
+ * @type {import('./types.js').StringifyOperations}
+ */
+export const default_operations = {
+	identify: (value) => value,
+
+	typeOf: (value) => (value === null ? 'null' : typeof value),
+
+	primitive: (value) => value,
+
+	tag: (value) => get_type(value),
+
+	isThenable: (value) => typeof value.then === 'function',
+
+	resolveThenable: (value) => Promise.resolve(value),
+
+	unbox: (value) => value.valueOf(),
+
+	dateISO: (value) => (isNaN(value.getDate()) ? '' : value.toISOString()),
+
+	toStringValue: (value) => value.toString(),
+
+	regExp: (value) => ({ source: value.source, flags: value.flags }),
+
+	setValues: (value) => value,
+
+	mapEntries: (value) => value,
+
+	viewInfo: (value) => ({
+		buffer: value.buffer,
+		byteOffset: value.byteOffset,
+		byteLength: value.byteLength,
+		length: value.length,
+		bufferByteLength: value.buffer.byteLength
+	}),
+
+	arrayBuffer: (value) => value,
+
+	arrayLength: (value) => value.length,
+
+	hasOwnIndex: (value, index) => Object.hasOwn(value, index),
+
+	arrayIndices: (value) => valid_array_indices(value),
+
+	objectShape: (value) => {
+		if (!is_plain_object(value)) return NOT_PLAIN;
+		if (enumerable_symbols(value).length > 0) return SYMBOL_KEYS;
+
+		return {
+			kind: Object.getPrototypeOf(value) === null ? 'null-proto' : 'plain',
+			keys: Object.keys(value)
+		};
+	},
+
+	get: (value, key) => value[key]
+};

--- a/src/operations.js
+++ b/src/operations.js
@@ -6,10 +6,10 @@ import {
 } from './utils.js';
 
 /** @type {{ kind: 'not-plain' }} */
-const NOT_PLAIN = { kind: 'not-plain' };
+const NOT_PLAIN = Object.freeze({ kind: 'not-plain' });
 
 /** @type {{ kind: 'symbol-keys' }} */
-const SYMBOL_KEYS = { kind: 'symbol-keys' };
+const SYMBOL_KEYS = Object.freeze({ kind: 'symbol-keys' });
 
 /**
  * The default implementations of every introspection/extraction operation
@@ -22,9 +22,12 @@ const SYMBOL_KEYS = { kind: 'symbol-keys' };
  * serialize values that live in a different JavaScript runtime (a `node:vm`
  * context, a WASM-hosted engine, a remote process) through handle objects.
  *
+ * The object is frozen — it is shared by every `stringify` call that does
+ * not override a given operation.
+ *
  * @type {import('./types.js').StringifyOperations}
  */
-export const default_operations = {
+export const default_operations = Object.freeze({
 	identify: (value) => value,
 
 	typeOf: (value) => (value === null ? 'null' : typeof value),
@@ -76,4 +79,4 @@ export const default_operations = {
 	},
 
 	get: (value, key) => value[key]
-};
+});

--- a/src/operations.js
+++ b/src/operations.js
@@ -13,8 +13,8 @@ const SYMBOL_KEYS = Object.freeze({ kind: 'symbol-keys' });
 
 /**
  * The default implementations of every introspection/extraction operation
- * `stringify` performs on the value being serialized. Each one matches the
- * behavior devalue has always had (native property access, iteration, etc).
+ * `stringify` performs on the value being serialized. Each one uses native
+ * JavaScript semantics (property access, iteration, prototype methods, etc).
  *
  * Pass overrides via the `operations` option of `stringify`/`stringifyAsync`
  * to customize how values are inspected — e.g. to serialize values without

--- a/src/operations.js
+++ b/src/operations.js
@@ -38,7 +38,7 @@ export const default_operations = Object.freeze({
 
 	isThenable: (value) => typeof value.then === 'function',
 
-	resolveThenable: (value) => Promise.resolve(value),
+	toPromise: (value) => Promise.resolve(value),
 
 	unbox: (value) => value.valueOf(),
 
@@ -64,7 +64,7 @@ export const default_operations = Object.freeze({
 
 	arrayLength: (value) => value.length,
 
-	hasOwnIndex: (value, index) => Object.hasOwn(value, index),
+	hasOwn: (value, key) => Object.hasOwn(value, key),
 
 	arrayIndices: (value) => valid_array_indices(value),
 

--- a/src/operations.js
+++ b/src/operations.js
@@ -32,43 +32,43 @@ export const default_operations = Object.freeze({
 
 	typeOf: (value) => (value === null ? 'null' : typeof value),
 
-	primitive: (value) => value,
+	toPrimitive: (value) => value,
 
-	tag: (value) => get_type(value),
+	tagOf: (value) => get_type(value),
 
 	isThenable: (value) => typeof value.then === 'function',
 
-	toPromise: (value) => Promise.resolve(value),
+	toPromise: (thenable) => Promise.resolve(thenable),
 
-	unbox: (value) => value.valueOf(),
+	unbox: (boxed) => boxed.valueOf(),
 
-	dateISO: (value) => (isNaN(value.getDate()) ? '' : value.toISOString()),
+	toISOString: (date) => (isNaN(date.getDate()) ? '' : date.toISOString()),
 
 	toStringValue: (value) => value.toString(),
 
-	regExp: (value) => ({ source: value.source, flags: value.flags }),
+	regExpInfo: (regexp) => ({ source: regexp.source, flags: regexp.flags }),
 
-	setValues: (value) => value,
+	valuesOf: (set) => set,
 
-	mapEntries: (value) => value,
+	entriesOf: (map) => map,
 
-	viewInfo: (value) => ({
-		buffer: value.buffer,
-		byteOffset: value.byteOffset,
-		byteLength: value.byteLength,
-		length: value.length,
-		bufferByteLength: value.buffer.byteLength
+	viewInfo: (view) => ({
+		buffer: view.buffer,
+		byteOffset: view.byteOffset,
+		byteLength: view.byteLength,
+		length: view.length,
+		bufferByteLength: view.buffer.byteLength
 	}),
 
-	arrayBuffer: (value) => value,
+	toArrayBuffer: (buffer) => buffer,
 
-	arrayLength: (value) => value.length,
+	lengthOf: (array) => array.length,
 
 	hasOwn: (value, key) => Object.hasOwn(value, key),
 
-	arrayIndices: (value) => valid_array_indices(value),
+	indicesOf: (array) => valid_array_indices(array),
 
-	objectShape: (value) => {
+	shapeOf: (value) => {
 		if (!is_plain_object(value)) return NOT_PLAIN;
 		if (enumerable_symbols(value).length > 0) return SYMBOL_KEYS;
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -69,9 +69,18 @@ export async function stringifyAsync(value, reducers, options) {
  */
 function run(async, value, reducers, options) {
 	/** @type {import('./types.js').StringifyOperations} */
-	const ops = options?.operations
-		? { ...default_operations, ...options.operations }
-		: default_operations;
+	let ops = default_operations;
+
+	if (options?.operations) {
+		ops = { ...default_operations };
+
+		// treat explicitly-`undefined` members like omitted members, so that
+		// programmatically-built overrides can't clobber a default with undefined
+		for (const key of /** @type {(keyof typeof ops)[]} */ (Object.keys(options.operations))) {
+			const fn = options.operations[key];
+			if (fn !== undefined) ops[key] = /** @type {any} */ (fn);
+		}
+	}
 
 	/** @type {any[]} */
 	const stringified = [];

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,13 +1,4 @@
-import {
-	DevalueError,
-	enumerable_symbols,
-	get_type,
-	is_plain_object,
-	is_primitive,
-	stringify_key,
-	stringify_string,
-	valid_array_indices
-} from './utils.js';
+import { DevalueError, stringify_key, stringify_string } from './utils.js';
 import {
 	HOLE,
 	NAN,
@@ -18,14 +9,16 @@ import {
 	UNDEFINED
 } from './constants.js';
 import { encode64 } from './base64.js';
+import { default_operations } from './operations.js';
 
 /**
  * Turn a value into a JSON string that can be parsed with `devalue.parse`
  * @param {any} value
  * @param {Record<string, (value: any) => any>} [reducers]
+ * @param {import('./types.js').StringifyOptions} [options]
  */
-export function stringify(value, reducers) {
-	const stringified = run(false, value, reducers);
+export function stringify(value, reducers, options) {
+	const stringified = run(false, value, reducers, options);
 	return typeof stringified === 'string' ? stringified : `[${stringified.join(',')}]`;
 }
 
@@ -33,9 +26,10 @@ export function stringify(value, reducers) {
  * Turn a value into a JSON string that can be parsed with `devalue.parse`
  * @param {any} value
  * @param {Record<string, (value: any) => any>} [reducers]
+ * @param {import('./types.js').StringifyOptions} [options]
  */
-export async function stringifyAsync(value, reducers) {
-	const stringified = run(true, value, reducers);
+export async function stringifyAsync(value, reducers, options) {
+	const stringified = run(true, value, reducers, options);
 
 	if (typeof stringified === 'string') {
 		return stringified;
@@ -71,8 +65,14 @@ export async function stringifyAsync(value, reducers) {
  * @param {boolean} async
  * @param {any} value
  * @param {Record<string, (value: any) => any>} [reducers]
+ * @param {import('./types.js').StringifyOptions} [options]
  */
-function run(async, value, reducers) {
+function run(async, value, reducers, options) {
+	/** @type {import('./types.js').StringifyOperations} */
+	const ops = options?.operations
+		? { ...default_operations, ...options.operations }
+		: default_operations;
+
 	/** @type {any[]} */
 	const stringified = [];
 
@@ -97,16 +97,27 @@ function run(async, value, reducers) {
 	 * @param {number} [index]
 	 */
 	function flatten(thing, index) {
-		if (thing === undefined) return UNDEFINED;
-		if (Number.isNaN(thing)) return NAN;
-		if (thing === Infinity) return POSITIVE_INFINITY;
-		if (thing === -Infinity) return NEGATIVE_INFINITY;
-		if (thing === 0 && 1 / thing < 0) return NEGATIVE_ZERO;
+		const type = ops.typeOf(thing);
 
-		if (indexes.has(thing)) return /** @type {number} */ (indexes.get(thing));
+		if (type === 'undefined') return UNDEFINED;
+
+		/** @type {number | undefined} */
+		let number;
+
+		if (type === 'number') {
+			number = /** @type {number} */ (ops.primitive(thing));
+			if (Number.isNaN(number)) return NAN;
+			if (number === Infinity) return POSITIVE_INFINITY;
+			if (number === -Infinity) return NEGATIVE_INFINITY;
+			if (number === 0 && 1 / number < 0) return NEGATIVE_ZERO;
+		}
+
+		const id = ops.identify(thing);
+
+		if (indexes.has(id)) return /** @type {number} */ (indexes.get(id));
 
 		index ??= p++;
-		indexes.set(thing, index);
+		indexes.set(id, index);
 
 		for (const { key, fn } of custom) {
 			const value = fn(thing);
@@ -116,18 +127,19 @@ function run(async, value, reducers) {
 			}
 		}
 
-		if (typeof thing === 'function') {
+		if (type === 'function') {
 			throw new DevalueError(`Cannot stringify a function`, keys, thing, value);
-		} else if (typeof thing === 'symbol') {
+		} else if (type === 'symbol') {
 			throw new DevalueError(`Cannot stringify a Symbol primitive`, keys, thing, value);
 		}
 
 		/** @type {string | Promise<any>} */
 		let str = '';
 
-		if (is_primitive(thing)) {
-			str = stringify_primitive(thing);
-		} else if (typeof thing.then === 'function') {
+		if (type !== 'object') {
+			// 'null' | 'boolean' | 'number' | 'bigint' | 'string'
+			str = stringify_primitive(type === 'number' ? number : ops.primitive(thing));
+		} else if (ops.isThenable(thing)) {
 			if (!async) {
 				throw new DevalueError(
 					`Cannot stringify a Promise or thenable — use stringifyAsync instead`,
@@ -137,36 +149,35 @@ function run(async, value, reducers) {
 				);
 			}
 
-			str = Promise.resolve(thing).then((value) => {
+			str = Promise.resolve(ops.resolveThenable(thing)).then((value) => {
 				const i = flatten(value, index);
 				if (i < 0) stringified[index] = i;
 			});
 		} else {
-			const type = get_type(thing);
+			const tag = ops.tag(thing);
 
-			switch (type) {
+			switch (tag) {
 				case 'Number':
 				case 'String':
 				case 'Boolean':
 				case 'BigInt':
-					str = `["Object",${flatten(thing.valueOf())}]`;
+					str = `["Object",${flatten(ops.unbox(thing))}]`;
 					break;
 
 				case 'Date':
-					const valid = !isNaN(thing.getDate());
-					str = `["Date","${valid ? thing.toISOString() : ''}"]`;
+					str = `["Date","${ops.dateISO(thing)}"]`;
 					break;
 
 				case 'URL':
-					str = `["URL",${stringify_string(thing.toString())}]`;
+					str = `["URL",${stringify_string(ops.toStringValue(thing))}]`;
 					break;
 
 				case 'URLSearchParams':
-					str = `["URLSearchParams",${stringify_string(thing.toString())}]`;
+					str = `["URLSearchParams",${stringify_string(ops.toStringValue(thing))}]`;
 					break;
 
 				case 'RegExp':
-					const { source, flags } = thing;
+					const { source, flags } = ops.regExp(thing);
 					str = flags
 						? `["RegExp",${stringify_string(source)},"${flags}"]`
 						: `["RegExp",${stringify_string(source)}]`;
@@ -182,14 +193,16 @@ function run(async, value, reducers) {
 					// is what protects against the DoS of e.g. `arr[1000000] = 1`.
 					let mostly_dense = false;
 
+					const length = ops.arrayLength(thing);
+
 					str = '[';
 
-					for (let i = 0; i < thing.length; i += 1) {
+					for (let i = 0; i < length; i += 1) {
 						if (i > 0) str += ',';
 
-						if (Object.hasOwn(thing, i)) {
+						if (ops.hasOwnIndex(thing, i)) {
 							keys.push(`[${i}]`);
-							str += flatten(thing[i]);
+							str += flatten(ops.get(thing, i));
 							keys.pop();
 						} else if (mostly_dense) {
 							// Use dense encoding. The heuristic guarantees the
@@ -228,19 +241,19 @@ function run(async, value, reducers) {
 							//
 							// Sparse encoding is cheaper when:
 							//   (4 + d) + P * (d + 1) < (L - P) * 3
-							const populated_keys = valid_array_indices(/** @type {any[]} */ (thing));
+							const populated_keys = ops.arrayIndices(thing);
 							const population = populated_keys.length;
-							const d = String(thing.length).length;
+							const d = String(length).length;
 
-							const hole_cost = (thing.length - population) * 3;
+							const hole_cost = (length - population) * 3;
 							const sparse_cost = 4 + d + population * (d + 1);
 
 							if (hole_cost > sparse_cost) {
-								str = '[' + SPARSE + ',' + thing.length;
+								str = '[' + SPARSE + ',' + length;
 								for (let j = 0; j < populated_keys.length; j++) {
 									const key = populated_keys[j];
 									keys.push(`[${key}]`);
-									str += ',' + key + ',' + flatten(thing[key]);
+									str += ',' + key + ',' + flatten(ops.get(thing, key));
 									keys.pop();
 								}
 								break;
@@ -259,7 +272,7 @@ function run(async, value, reducers) {
 				case 'Set':
 					str = '["Set"';
 
-					for (const value of thing) {
+					for (const value of ops.setValues(thing)) {
 						str += `,${flatten(value)}`;
 					}
 
@@ -269,8 +282,13 @@ function run(async, value, reducers) {
 				case 'Map':
 					str = '["Map"';
 
-					for (const [key, value] of thing) {
-						keys.push(`.get(${is_primitive(key) ? stringify_primitive(key) : '...'})`);
+					for (const [key, value] of ops.mapEntries(thing)) {
+						const key_type = ops.typeOf(key);
+						const key_is_primitive =
+							key_type !== 'object' && key_type !== 'function' && key_type !== 'symbol';
+						keys.push(
+							`.get(${key_is_primitive ? stringify_primitive(ops.primitive(key)) : '...'})`
+						);
 						str += `,${flatten(key)},${flatten(value)}`;
 						keys.pop();
 					}
@@ -290,13 +308,12 @@ function run(async, value, reducers) {
 				case 'Float64Array':
 				case 'BigInt64Array':
 				case 'BigUint64Array': {
-					/** @type {import("./types.js").TypedArray} */
-					const typedArray = thing;
-					str = '["' + type + '",' + flatten(typedArray.buffer);
+					const info = ops.viewInfo(thing);
+					str = '["' + tag + '",' + flatten(info.buffer);
 
 					// handle subarrays
-					if (typedArray.byteLength !== typedArray.buffer.byteLength) {
-						str += `,${typedArray.byteOffset},${typedArray.length}`;
+					if (info.byteLength !== info.bufferByteLength) {
+						str += `,${info.byteOffset},${info.length}`;
 					}
 
 					str += ']';
@@ -304,12 +321,11 @@ function run(async, value, reducers) {
 				}
 
 				case 'DataView': {
-					/** @type {DataView} */
-					const view = thing;
-					str = '["' + type + '",' + flatten(view.buffer);
+					const info = ops.viewInfo(thing);
+					str = '["' + tag + '",' + flatten(info.buffer);
 
-					if (view.byteLength !== view.buffer.byteLength) {
-						str += `,${view.byteOffset},${view.byteLength}`;
+					if (info.byteLength !== info.bufferByteLength) {
+						str += `,${info.byteOffset},${info.byteLength}`;
 					}
 
 					str += ']';
@@ -317,9 +333,7 @@ function run(async, value, reducers) {
 				}
 
 				case 'ArrayBuffer': {
-					/** @type {ArrayBuffer} */
-					const arraybuffer = thing;
-					const base64 = encode64(arraybuffer);
+					const base64 = encode64(ops.arrayBuffer(thing));
 
 					str = `["ArrayBuffer","${base64}"]`;
 					break;
@@ -333,21 +347,23 @@ function run(async, value, reducers) {
 				case 'Temporal.PlainMonthDay':
 				case 'Temporal.PlainYearMonth':
 				case 'Temporal.ZonedDateTime':
-					str = `["${type}",${stringify_string(thing.toString())}]`;
+					str = `["${tag}",${stringify_string(ops.toStringValue(thing))}]`;
 					break;
 
-				default:
-					if (!is_plain_object(thing)) {
+				default: {
+					const shape = ops.objectShape(thing);
+
+					if (shape.kind === 'not-plain') {
 						throw new DevalueError(`Cannot stringify arbitrary non-POJOs`, keys, thing, value);
 					}
 
-					if (enumerable_symbols(thing).length > 0) {
+					if (shape.kind === 'symbol-keys') {
 						throw new DevalueError(`Cannot stringify POJOs with symbolic keys`, keys, thing, value);
 					}
 
-					if (Object.getPrototypeOf(thing) === null) {
+					if (shape.kind === 'null-proto') {
 						str = '["null"';
-						for (const key of Object.keys(thing)) {
+						for (const key of shape.keys) {
 							if (key === '__proto__') {
 								throw new DevalueError(
 									`Cannot stringify objects with __proto__ keys`,
@@ -358,14 +374,14 @@ function run(async, value, reducers) {
 							}
 
 							keys.push(stringify_key(key));
-							str += `,${stringify_string(key)},${flatten(thing[key])}`;
+							str += `,${stringify_string(key)},${flatten(ops.get(thing, key))}`;
 							keys.pop();
 						}
 						str += ']';
 					} else {
 						str = '{';
 						let started = false;
-						for (const key of Object.keys(thing)) {
+						for (const key of shape.keys) {
 							if (key === '__proto__') {
 								throw new DevalueError(
 									`Cannot stringify objects with __proto__ keys`,
@@ -378,11 +394,12 @@ function run(async, value, reducers) {
 							if (started) str += ',';
 							started = true;
 							keys.push(stringify_key(key));
-							str += `${stringify_string(key)}:${flatten(thing[key])}`;
+							str += `${stringify_string(key)}:${flatten(ops.get(thing, key))}`;
 							keys.pop();
 						}
 						str += '}';
 					}
+				}
 			}
 		}
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -72,13 +72,15 @@ function run(async, value, reducers, options) {
 	let ops = default_operations;
 
 	if (options?.operations) {
-		ops = { ...default_operations };
+		ops = /** @type {import('./types.js').StringifyOperations} */ ({});
 
-		// treat explicitly-`undefined` members like omitted members, so that
-		// programmatically-built overrides can't clobber a default with undefined
-		for (const key of /** @type {(keyof typeof ops)[]} */ (Object.keys(options.operations))) {
-			const fn = options.operations[key];
-			if (fn !== undefined) ops[key] = /** @type {any} */ (fn);
+		// iterating the default keys (rather than the override's own keys) means
+		// nullish members fall back to the default, and inherited members — e.g.
+		// from a class instance — are picked up
+		for (const key of /** @type {(keyof typeof ops)[]} */ (
+			Object.keys(default_operations)
+		)) {
+			ops[key] = options.operations[key] ?? default_operations[key];
 		}
 	}
 
@@ -113,6 +115,9 @@ function run(async, value, reducers, options) {
 		/** @type {number | undefined} */
 		let number;
 
+		// `ops.primitive` is the boundary between the value being serialized and
+		// plain host JavaScript: everything below operates on the extracted host
+		// primitive, so native comparisons and arithmetic are correct there.
 		if (type === 'number') {
 			number = /** @type {number} */ (ops.primitive(thing));
 			if (Number.isNaN(number)) return NAN;
@@ -146,7 +151,6 @@ function run(async, value, reducers, options) {
 		let str = '';
 
 		if (type !== 'object') {
-			// 'null' | 'boolean' | 'number' | 'bigint' | 'string'
 			str = stringify_primitive(type === 'number' ? number : ops.primitive(thing));
 		} else if (ops.isThenable(thing)) {
 			if (!async) {
@@ -158,7 +162,7 @@ function run(async, value, reducers, options) {
 				);
 			}
 
-			str = Promise.resolve(ops.resolveThenable(thing)).then((value) => {
+			str = ops.toPromise(thing).then((value) => {
 				const i = flatten(value, index);
 				if (i < 0) stringified[index] = i;
 			});
@@ -209,7 +213,7 @@ function run(async, value, reducers, options) {
 					for (let i = 0; i < length; i += 1) {
 						if (i > 0) str += ',';
 
-						if (ops.hasOwnIndex(thing, i)) {
+						if (ops.hasOwn(thing, i)) {
 							keys.push(`[${i}]`);
 							str += flatten(ops.get(thing, i));
 							keys.pop();

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -115,11 +115,11 @@ function run(async, value, reducers, options) {
 		/** @type {number | undefined} */
 		let number;
 
-		// `ops.primitive` is the boundary between the value being serialized and
+		// `ops.toPrimitive` is the boundary between the value being serialized and
 		// plain host JavaScript: everything below operates on the extracted host
 		// primitive, so native comparisons and arithmetic are correct there.
 		if (type === 'number') {
-			number = /** @type {number} */ (ops.primitive(thing));
+			number = /** @type {number} */ (ops.toPrimitive(thing));
 			if (Number.isNaN(number)) return NAN;
 			if (number === Infinity) return POSITIVE_INFINITY;
 			if (number === -Infinity) return NEGATIVE_INFINITY;
@@ -151,7 +151,7 @@ function run(async, value, reducers, options) {
 		let str = '';
 
 		if (type !== 'object') {
-			str = stringify_primitive(type === 'number' ? number : ops.primitive(thing));
+			str = stringify_primitive(type === 'number' ? number : ops.toPrimitive(thing));
 		} else if (ops.isThenable(thing)) {
 			if (!async) {
 				throw new DevalueError(
@@ -167,7 +167,7 @@ function run(async, value, reducers, options) {
 				if (i < 0) stringified[index] = i;
 			});
 		} else {
-			const tag = ops.tag(thing);
+			const tag = ops.tagOf(thing);
 
 			switch (tag) {
 				case 'Number':
@@ -178,7 +178,7 @@ function run(async, value, reducers, options) {
 					break;
 
 				case 'Date':
-					str = `["Date","${ops.dateISO(thing)}"]`;
+					str = `["Date","${ops.toISOString(thing)}"]`;
 					break;
 
 				case 'URL':
@@ -190,7 +190,7 @@ function run(async, value, reducers, options) {
 					break;
 
 				case 'RegExp':
-					const { source, flags } = ops.regExp(thing);
+					const { source, flags } = ops.regExpInfo(thing);
 					str = flags
 						? `["RegExp",${stringify_string(source)},"${flags}"]`
 						: `["RegExp",${stringify_string(source)}]`;
@@ -206,7 +206,7 @@ function run(async, value, reducers, options) {
 					// is what protects against the DoS of e.g. `arr[1000000] = 1`.
 					let mostly_dense = false;
 
-					const length = ops.arrayLength(thing);
+					const length = ops.lengthOf(thing);
 
 					str = '[';
 
@@ -254,7 +254,7 @@ function run(async, value, reducers, options) {
 							//
 							// Sparse encoding is cheaper when:
 							//   (4 + d) + P * (d + 1) < (L - P) * 3
-							const populated_keys = ops.arrayIndices(thing);
+							const populated_keys = ops.indicesOf(thing);
 							const population = populated_keys.length;
 							const d = String(length).length;
 
@@ -285,7 +285,7 @@ function run(async, value, reducers, options) {
 				case 'Set':
 					str = '["Set"';
 
-					for (const value of ops.setValues(thing)) {
+					for (const value of ops.valuesOf(thing)) {
 						str += `,${flatten(value)}`;
 					}
 
@@ -295,12 +295,12 @@ function run(async, value, reducers, options) {
 				case 'Map':
 					str = '["Map"';
 
-					for (const [key, value] of ops.mapEntries(thing)) {
+					for (const [key, value] of ops.entriesOf(thing)) {
 						const key_type = ops.typeOf(key);
 						const key_is_primitive =
 							key_type !== 'object' && key_type !== 'function' && key_type !== 'symbol';
 						keys.push(
-							`.get(${key_is_primitive ? stringify_primitive(ops.primitive(key)) : '...'})`
+							`.get(${key_is_primitive ? stringify_primitive(ops.toPrimitive(key)) : '...'})`
 						);
 						str += `,${flatten(key)},${flatten(value)}`;
 						keys.pop();
@@ -346,7 +346,7 @@ function run(async, value, reducers, options) {
 				}
 
 				case 'ArrayBuffer': {
-					const base64 = encode64(ops.arrayBuffer(thing));
+					const base64 = encode64(ops.toArrayBuffer(thing));
 
 					str = `["ArrayBuffer","${base64}"]`;
 					break;
@@ -364,7 +364,7 @@ function run(async, value, reducers, options) {
 					break;
 
 				default: {
-					const shape = ops.objectShape(thing);
+					const shape = ops.shapeOf(thing);
 
 					if (shape.kind === 'not-plain') {
 						throw new DevalueError(`Cannot stringify arbitrary non-POJOs`, keys, thing, value);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,3 +11,177 @@ export type TypedArray =
 	| Float64Array
 	| BigInt64Array
 	| BigUint64Array;
+
+/**
+ * The introspection/extraction operations `stringify` performs on the value
+ * being serialized. Every dynamic operation — property reads, prototype
+ * method calls, iteration, type classification — goes through this
+ * interface, so overriding members lets you control exactly how values are
+ * inspected.
+ *
+ * Use cases:
+ * - **Side-effect-free serialization**: replace operations that can execute
+ *   user code (getters, proxy traps, patched prototypes, `Symbol.toStringTag`
+ *   accessors) with implementations based on captured intrinsics, internal
+ *   slots, or property descriptors.
+ * - **Foreign-runtime serialization**: serialize values that live in another
+ *   JavaScript runtime (a `node:vm` context, a WASM-hosted engine, a remote
+ *   process) by implementing the operations over handle objects. The
+ *   `stringify` algorithm never touches the value directly, so "value" can
+ *   be any opaque token as long as the operations agree on what it means.
+ *
+ * All members are optional when passed to `stringify` — omitted members fall
+ * back to the defaults (native behavior, exported as `defaultOperations`).
+ */
+export interface StringifyOperations {
+	/**
+	 * Returns the key used for deduplication and cycle detection (compared
+	 * with `Map` key semantics). Two values that represent the same logical
+	 * object must return the same key. Default: the value itself.
+	 *
+	 * Override this when serializing through handles, where two distinct
+	 * handle objects may refer to the same underlying value.
+	 */
+	identify(value: any): unknown;
+
+	/**
+	 * Classifies a value. Same contract as the `typeof` operator, except
+	 * `null` must be reported as `'null'` (not `'object'`).
+	 */
+	typeOf(value: any):
+		| 'undefined'
+		| 'null'
+		| 'boolean'
+		| 'number'
+		| 'bigint'
+		| 'string'
+		| 'symbol'
+		| 'function'
+		| 'object';
+
+	/**
+	 * Extracts the host-JavaScript primitive from a value whose `typeOf` is
+	 * `'null'`, `'boolean'`, `'number'`, `'bigint'` or `'string'`.
+	 * Default: the value itself (it already is the primitive).
+	 */
+	primitive(value: any): undefined | null | boolean | number | bigint | string;
+
+	/**
+	 * Returns the brand of an object value — the strings produced by
+	 * `Object.prototype.toString` without the wrapping (`'Date'`, `'Array'`,
+	 * `'Map'`, `'Object'`, `'Temporal.Instant'`, …). This decides which
+	 * serialization strategy is used, so hardened implementations should use
+	 * engine-level brand checks rather than (spoofable, getter-invoking)
+	 * `Symbol.toStringTag` lookups.
+	 */
+	tag(value: any): string;
+
+	/** Returns true if the object value should be treated as a thenable. */
+	isThenable(value: any): boolean;
+
+	/**
+	 * Resolves a thenable to its settled value (which is then serialized).
+	 * Only called from `stringifyAsync` for values where `isThenable`
+	 * returned true.
+	 */
+	resolveThenable(value: any): Promise<any>;
+
+	/**
+	 * Extracts the inner value of a boxed primitive (`Number`, `String`,
+	 * `Boolean`, `BigInt` objects). Equivalent to `value.valueOf()`. The
+	 * result is serialized recursively, so it may be a foreign value/handle.
+	 */
+	unbox(value: any): any;
+
+	/**
+	 * Returns the ISO string for a `Date` value, or `''` for an invalid
+	 * date. Equivalent to `value.toISOString()`.
+	 */
+	dateISO(value: any): string;
+
+	/**
+	 * Returns the string form of a `URL`, `URLSearchParams` or `Temporal.*`
+	 * value. Equivalent to `value.toString()`.
+	 */
+	toStringValue(value: any): string;
+
+	/** Returns the source and flags of a `RegExp` value. */
+	regExp(value: any): { source: string; flags: string };
+
+	/**
+	 * Returns an iterable over the elements of a `Set` value. The iterable
+	 * is consumed on the host; elements may be foreign values/handles.
+	 */
+	setValues(value: any): Iterable<any>;
+
+	/**
+	 * Returns an iterable over the `[key, value]` entries of a `Map` value.
+	 * The iterable is consumed on the host; keys/values may be foreign
+	 * values/handles.
+	 */
+	mapEntries(value: any): Iterable<[any, any]>;
+
+	/**
+	 * Returns the view metadata of a typed array or `DataView` value.
+	 * `length` is only meaningful for typed arrays. `buffer` is serialized
+	 * recursively, so it may be a foreign value/handle.
+	 */
+	viewInfo(value: any): {
+		buffer: any;
+		byteOffset: number;
+		byteLength: number;
+		length?: number;
+		bufferByteLength: number;
+	};
+
+	/**
+	 * Returns a host `ArrayBuffer` with the bytes of an `ArrayBuffer` value.
+	 * Default: the value itself. Foreign-runtime implementations should copy
+	 * the bytes into a host buffer.
+	 */
+	arrayBuffer(value: any): ArrayBuffer;
+
+	/** Returns the length of an `Array` value. */
+	arrayLength(value: any): number;
+
+	/** Returns true if an `Array` value has an own element at `index`. */
+	hasOwnIndex(value: any, index: number): boolean;
+
+	/**
+	 * Returns the populated indices of a (sparse) `Array` value as strings,
+	 * in ascending order. Equivalent to `Object.keys(value)` filtered to
+	 * valid array indices.
+	 */
+	arrayIndices(value: any): string[];
+
+	/**
+	 * Classifies a plain-object candidate:
+	 * - `{ kind: 'plain' | 'null-proto', keys }` — a serializable POJO and
+	 *   its own enumerable string keys
+	 * - `{ kind: 'not-plain' }` — a non-POJO (stringify throws)
+	 * - `{ kind: 'symbol-keys' }` — a POJO with enumerable symbol keys
+	 *   (stringify throws)
+	 */
+	objectShape(
+		value: any
+	):
+		| { kind: 'plain' | 'null-proto'; keys: string[] }
+		| { kind: 'not-plain' }
+		| { kind: 'symbol-keys' };
+
+	/**
+	 * Reads a property from an `Array` or plain-object value. Equivalent to
+	 * `value[key]`. Hardened implementations can read through property
+	 * descriptors to control what happens for accessor properties.
+	 */
+	get(value: any, key: string | number): any;
+}
+
+/** Options for `stringify` and `stringifyAsync`. */
+export interface StringifyOptions {
+	/**
+	 * Overrides for the introspection/extraction operations used while
+	 * serializing. Omitted members fall back to `defaultOperations`.
+	 */
+	operations?: Partial<StringifyOperations>;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -41,6 +41,14 @@ export interface StringifyOperations {
 	 *
 	 * Override this when serializing through handles, where two distinct
 	 * handle objects may refer to the same underlying value.
+	 *
+	 * Keys are compared across *every* value in the payload, including
+	 * primitives, so an implementation that derives keys for objects must
+	 * make sure they cannot collide with a primitive that appears in the
+	 * same payload — returning e.g. the string `'42'` as an object's key
+	 * would alias it to the string `'42'` elsewhere in the payload and emit
+	 * a wrong back-reference. Prefer keys that are unforgeable, such as the
+	 * underlying object itself, a symbol, or a wrapper object.
 	 */
 	identify(value: any): unknown;
 
@@ -80,11 +88,12 @@ export interface StringifyOperations {
 	isThenable(value: any): boolean;
 
 	/**
-	 * Resolves a thenable to its settled value (which is then serialized).
-	 * Only called from `stringifyAsync` for values where `isThenable`
-	 * returned true.
+	 * Converts a thenable into a native promise, whose settled value is then
+	 * serialized. The returned promise may reject, in which case
+	 * `stringifyAsync` rejects. Only called from `stringifyAsync`, for values
+	 * where `isThenable` returned true.
 	 */
-	resolveThenable(value: any): Promise<any>;
+	toPromise(value: any): Promise<any>;
 
 	/**
 	 * Extracts the inner value of a boxed primitive (`Number`, `String`,
@@ -144,8 +153,11 @@ export interface StringifyOperations {
 	/** Returns the length of an `Array` value. */
 	arrayLength(value: any): number;
 
-	/** Returns true if an `Array` value has an own element at `index`. */
-	hasOwnIndex(value: any, index: number): boolean;
+	/**
+	 * Returns true if a value has an own property at `key`. Same contract as
+	 * `Object.hasOwn(value, key)`.
+	 */
+	hasOwn(value: any, key: string | number): boolean;
 
 	/**
 	 * Returns the populated indices of a (sparse) `Array` value as strings,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,6 +32,22 @@ export type TypedArray =
  *
  * All members are optional when passed to `stringify` — omitted members fall
  * back to the defaults (native behavior, exported as `defaultOperations`).
+ *
+ * Members are named by what they do with the value:
+ * - `isXxx`/`hasXxx` — predicates returning booleans
+ * - `toXxx` — conversions whose whole result crosses into host JavaScript
+ *   (`toPrimitive`, `toISOString`) or into a native container (`toPromise`)
+ * - `xxxOf` — queries returning host data *about* the value (`typeOf`,
+ *   `tagOf`, `lengthOf`) or its constituents, which remain in value space
+ *   (`valuesOf`, `entriesOf`)
+ * - `xxxInfo` — multi-field descriptors mixing host data and constituent
+ *   values (`viewInfo`, `regExpInfo`)
+ * - bare verbs (`get`, `unbox`, `identify`) — accessors whose results remain
+ *   in value space
+ *
+ * (`toStringValue` and `unbox` deliberately avoid the names `toString` and
+ * `valueOf`, which would shadow `Object.prototype` methods on the operations
+ * object.)
  */
 export interface StringifyOperations {
 	/**
@@ -72,7 +88,7 @@ export interface StringifyOperations {
 	 * `'null'`, `'boolean'`, `'number'`, `'bigint'` or `'string'`.
 	 * Default: the value itself (it already is the primitive).
 	 */
-	primitive(value: any): undefined | null | boolean | number | bigint | string;
+	toPrimitive(value: any): undefined | null | boolean | number | bigint | string;
 
 	/**
 	 * Returns the brand of an object value — the strings produced by
@@ -82,7 +98,7 @@ export interface StringifyOperations {
 	 * engine-level brand checks rather than (spoofable, getter-invoking)
 	 * `Symbol.toStringTag` lookups.
 	 */
-	tag(value: any): string;
+	tagOf(value: any): string;
 
 	/** Returns true if the object value should be treated as a thenable. */
 	isThenable(value: any): boolean;
@@ -93,20 +109,20 @@ export interface StringifyOperations {
 	 * `stringifyAsync` rejects. Only called from `stringifyAsync`, for values
 	 * where `isThenable` returned true.
 	 */
-	toPromise(value: any): Promise<any>;
+	toPromise(thenable: any): Promise<any>;
 
 	/**
 	 * Extracts the inner value of a boxed primitive (`Number`, `String`,
-	 * `Boolean`, `BigInt` objects). Equivalent to `value.valueOf()`. The
+	 * `Boolean`, `BigInt` objects). Equivalent to `boxed.valueOf()`. The
 	 * result is serialized recursively, so it may be a foreign value/handle.
 	 */
-	unbox(value: any): any;
+	unbox(boxed: any): any;
 
 	/**
 	 * Returns the ISO string for a `Date` value, or `''` for an invalid
-	 * date. Equivalent to `value.toISOString()`.
+	 * date. Equivalent to `date.toISOString()`.
 	 */
-	dateISO(value: any): string;
+	toISOString(date: any): string;
 
 	/**
 	 * Returns the string form of a `URL`, `URLSearchParams` or `Temporal.*`
@@ -115,27 +131,27 @@ export interface StringifyOperations {
 	toStringValue(value: any): string;
 
 	/** Returns the source and flags of a `RegExp` value. */
-	regExp(value: any): { source: string; flags: string };
+	regExpInfo(regexp: any): { source: string; flags: string };
 
 	/**
 	 * Returns an iterable over the elements of a `Set` value. The iterable
 	 * is consumed on the host; elements may be foreign values/handles.
 	 */
-	setValues(value: any): Iterable<any>;
+	valuesOf(set: any): Iterable<any>;
 
 	/**
 	 * Returns an iterable over the `[key, value]` entries of a `Map` value.
 	 * The iterable is consumed on the host; keys/values may be foreign
 	 * values/handles.
 	 */
-	mapEntries(value: any): Iterable<[any, any]>;
+	entriesOf(map: any): Iterable<[any, any]>;
 
 	/**
 	 * Returns the view metadata of a typed array or `DataView` value.
 	 * `length` is only meaningful for typed arrays. `buffer` is serialized
 	 * recursively, so it may be a foreign value/handle.
 	 */
-	viewInfo(value: any): {
+	viewInfo(view: any): {
 		buffer: any;
 		byteOffset: number;
 		byteLength: number;
@@ -148,10 +164,10 @@ export interface StringifyOperations {
 	 * Default: the value itself. Foreign-runtime implementations should copy
 	 * the bytes into a host buffer.
 	 */
-	arrayBuffer(value: any): ArrayBuffer;
+	toArrayBuffer(buffer: any): ArrayBuffer;
 
 	/** Returns the length of an `Array` value. */
-	arrayLength(value: any): number;
+	lengthOf(array: any): number;
 
 	/**
 	 * Returns true if a value has an own property at `key`. Same contract as
@@ -161,10 +177,10 @@ export interface StringifyOperations {
 
 	/**
 	 * Returns the populated indices of a (sparse) `Array` value as strings,
-	 * in ascending order. Equivalent to `Object.keys(value)` filtered to
+	 * in ascending order. Equivalent to `Object.keys(array)` filtered to
 	 * valid array indices.
 	 */
-	arrayIndices(value: any): string[];
+	indicesOf(array: any): string[];
 
 	/**
 	 * Classifies a plain-object candidate:
@@ -174,7 +190,7 @@ export interface StringifyOperations {
 	 * - `{ kind: 'symbol-keys' }` — a POJO with enumerable symbol keys
 	 *   (stringify throws)
 	 */
-	objectShape(
+	shapeOf(
 		value: any
 	):
 		| { kind: 'plain' | 'null-proto'; keys: string[] }

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -40,6 +40,31 @@ suite('operations option', (test) => {
 		assert.equal(calls, 4);
 	});
 
+	test('explicitly-undefined overrides fall back to defaults', () => {
+		// programmatically-built override objects often carry undefined members
+		const result = stringify(
+			{ a: 1, date: new Date(1700000000000) },
+			undefined,
+			{
+				operations: {
+					get: undefined,
+					dateISO: undefined,
+					tag: (value) => defaultOperations.tag(value)
+				}
+			}
+		);
+
+		assert.equal(result, stringify({ a: 1, date: new Date(1700000000000) }));
+	});
+
+	test('defaultOperations and objectShape sentinels are frozen', () => {
+		assert.ok(Object.isFrozen(defaultOperations));
+		assert.ok(Object.isFrozen(defaultOperations.objectShape(new Map())));
+		assert.ok(
+			Object.isFrozen(defaultOperations.objectShape({ [Symbol('key')]: 1 }))
+		);
+	});
+
 	test('defaultOperations is exported and delegable', () => {
 		const result = stringify(new Map([['k', 'v']]), undefined, {
 			operations: {

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -1,0 +1,409 @@
+import * as assert from 'uvu/assert';
+import * as uvu from 'uvu';
+import { stringify, stringifyAsync, defaultOperations, parse } from '../index.js';
+
+globalThis.Temporal ??= (await import('@js-temporal/polyfill')).Temporal;
+
+/**
+ * @param {string} name
+ * @param {(test: import('uvu').Test) => void} fn
+ */
+function suite(name, fn) {
+	const test = uvu.suite(name);
+	fn(test);
+	test.run();
+}
+
+// ---------------------------------------------------------------------------
+// Custom operations: basic plumbing
+// ---------------------------------------------------------------------------
+
+suite('operations option', (test) => {
+	test('partial overrides merge over defaults', () => {
+		let calls = 0;
+
+		const result = stringify(
+			{ a: 1, b: [2, 3] },
+			undefined,
+			{
+				operations: {
+					get(value, key) {
+						calls += 1;
+						return value[key];
+					}
+				}
+			}
+		);
+
+		assert.equal(result, stringify({ a: 1, b: [2, 3] }));
+		// a, b, b[0], b[1]
+		assert.equal(calls, 4);
+	});
+
+	test('defaultOperations is exported and delegable', () => {
+		const result = stringify(new Map([['k', 'v']]), undefined, {
+			operations: {
+				mapEntries: (value) => defaultOperations.mapEntries(value)
+			}
+		});
+
+		assert.equal(result, stringify(new Map([['k', 'v']])));
+	});
+
+	test('identify controls deduplication and cycle detection', () => {
+		// Two distinct wrapper objects representing the same logical value
+		// (the handle scenario) must serialize as one deduplicated entry.
+		class Wrapper {
+			constructor(inner) {
+				this.inner = inner;
+			}
+		}
+
+		const shared = { x: 1 };
+		const a = new Wrapper(shared);
+		const b = new Wrapper(shared);
+
+		/** @type {import('../src/types.js').StringifyOperations['objectShape']} */
+		const objectShape = (value) =>
+			value instanceof Wrapper
+				? defaultOperations.objectShape(value.inner)
+				: defaultOperations.objectShape(value);
+
+		const result = stringify([a, b], undefined, {
+			operations: {
+				identify: (value) => (value instanceof Wrapper ? value.inner : value),
+				tag: (value) => (value instanceof Wrapper ? 'Object' : defaultOperations.tag(value)),
+				objectShape,
+				get: (value, key) =>
+					value instanceof Wrapper ? value.inner[key] : value[key]
+			}
+		});
+
+		assert.equal(result, stringify([shared, shared]));
+		assert.equal(parse(result)[0], parse(result)[1]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Side-effect-free serialization
+// ---------------------------------------------------------------------------
+
+suite('side-effect-free operations', (test) => {
+	test('dateISO override avoids patched Date.prototype.toISOString', () => {
+		const original = Date.prototype.toISOString;
+		let patched_calls = 0;
+		// eslint-disable-next-line no-extend-native
+		Date.prototype.toISOString = function () {
+			patched_calls += 1;
+			return original.call(this);
+		};
+
+		try {
+			const date = new Date(1700000000000);
+
+			// default ops call the (patched) prototype method
+			stringify(date);
+			assert.equal(patched_calls, 1);
+
+			// hardened ops use a captured intrinsic
+			const result = stringify(date, undefined, {
+				operations: {
+					dateISO: (value) => original.call(value)
+				}
+			});
+
+			assert.equal(patched_calls, 1); // unchanged
+			assert.equal(result, `[["Date","2023-11-14T22:13:20.000Z"]]`);
+		} finally {
+			// eslint-disable-next-line no-extend-native
+			Date.prototype.toISOString = original;
+		}
+	});
+
+	test('mapEntries/setValues overrides avoid patched Symbol.iterator', () => {
+		const map_entries = Map.prototype.entries;
+		const set_values = Set.prototype.values;
+		const map_iterator = Map.prototype[Symbol.iterator];
+		const set_iterator = Set.prototype[Symbol.iterator];
+		let patched_calls = 0;
+
+		Map.prototype[Symbol.iterator] = function () {
+			patched_calls += 1;
+			return map_entries.call(this);
+		};
+		Set.prototype[Symbol.iterator] = function () {
+			patched_calls += 1;
+			return set_values.call(this);
+		};
+
+		try {
+			const value = { map: new Map([[1, 2]]), set: new Set([3]) };
+
+			const result = stringify(value, undefined, {
+				operations: {
+					mapEntries: (map) => map_entries.call(map),
+					setValues: (set) => set_values.call(set)
+				}
+			});
+
+			assert.equal(patched_calls, 0);
+			assert.equal(result, stringify({ map: new Map([[1, 2]]), set: new Set([3]) }));
+		} finally {
+			Map.prototype[Symbol.iterator] = map_iterator;
+			Set.prototype[Symbol.iterator] = set_iterator;
+		}
+	});
+
+	test('tag override is not fooled by Symbol.toStringTag getters', () => {
+		let getter_calls = 0;
+
+		const sneaky = {};
+		Object.defineProperty(sneaky, Symbol.toStringTag, {
+			get() {
+				getter_calls += 1;
+				return 'Date';
+			}
+		});
+
+		// default ops consult Object.prototype.toString, which reads the
+		// (getter-defined) Symbol.toStringTag — executing user code and
+		// misclassifying the object
+		assert.throws(() => stringify(sneaky));
+		assert.ok(getter_calls > 0);
+
+		getter_calls = 0;
+
+		// hardened ops use brand checks — here simplified to "trust nothing"
+		const result = stringify(sneaky, undefined, {
+			operations: {
+				tag: (value) => {
+					if (value instanceof Date) return 'Date';
+					if (Array.isArray(value)) return 'Array';
+					return 'Object';
+				}
+			}
+		});
+
+		assert.equal(getter_calls, 0);
+		assert.equal(result, '[{}]');
+	});
+
+	test('get override reads through descriptors without invoking getters', () => {
+		let getter_calls = 0;
+
+		const thing = {
+			plain: 'data',
+			get computed() {
+				getter_calls += 1;
+				return 'side effect!';
+			}
+		};
+
+		/** @type {import('../src/types.js').StringifyOperations['get']} */
+		const get = (value, key) => {
+			const descriptor = Object.getOwnPropertyDescriptor(value, key);
+			if (descriptor && (descriptor.get || descriptor.set)) {
+				throw new Error(`refusing to invoke getter for "${key}"`);
+			}
+			return descriptor ? descriptor.value : undefined;
+		};
+
+		assert.throws(
+			() => stringify(thing, undefined, { operations: { get } }),
+			/refusing to invoke getter for "computed"/
+		);
+		assert.equal(getter_calls, 0);
+
+		// default behavior does invoke the getter
+		stringify(thing);
+		assert.equal(getter_calls, 1);
+	});
+
+	test('isThenable override avoids .then getter execution', () => {
+		let then_reads = 0;
+
+		const trap = {
+			marker: true
+		};
+		Object.defineProperty(trap, 'then', {
+			get() {
+				then_reads += 1;
+				return undefined;
+			}
+		});
+
+		stringify(trap, undefined, {
+			operations: {
+				isThenable: (value) => value instanceof Promise,
+				objectShape: (value) => ({
+					kind: 'plain',
+					keys: Object.keys(value)
+				})
+			}
+		});
+
+		assert.equal(then_reads, 0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Foreign-runtime (handle-based) serialization
+// ---------------------------------------------------------------------------
+
+// A stand-in for a VM value handle (e.g. a QuickJS-in-WASM JSValueHandle):
+// the serializer never touches the underlying value directly — every
+// introspection goes through the operations implementation below.
+class Handle {
+	/** @param {any} value */
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+/** @param {any} value */
+const h = (value) => new Handle(value);
+
+/** @param {Handle} handle */
+const raw = (handle) => /** @type {Handle} */ (handle).value;
+
+/**
+ * A complete operations implementation over Handle-wrapped values. Mirrors
+ * how a real foreign-runtime integration would work: `identify` unwraps to
+ * the underlying identity, every extraction returns host values, and every
+ * recursive value (array elements, map entries, buffers, …) is re-wrapped
+ * in a fresh Handle to prove that deduplication does not depend on handle
+ * identity.
+ *
+ * @type {import('../src/types.js').StringifyOperations}
+ */
+const handle_operations = {
+	identify: (handle) => raw(handle),
+	typeOf: (handle) => {
+		const value = raw(handle);
+		return value === null ? 'null' : typeof value;
+	},
+	primitive: (handle) => raw(handle),
+	tag: (handle) => defaultOperations.tag(raw(handle)),
+	isThenable: (handle) => typeof raw(handle).then === 'function',
+	resolveThenable: (handle) => Promise.resolve(raw(handle)).then(h),
+	unbox: (handle) => h(raw(handle).valueOf()),
+	dateISO: (handle) => defaultOperations.dateISO(raw(handle)),
+	toStringValue: (handle) => raw(handle).toString(),
+	regExp: (handle) => defaultOperations.regExp(raw(handle)),
+	setValues: (handle) => [...raw(handle)].map(h),
+	mapEntries: (handle) => [...raw(handle)].map(([k, v]) => [h(k), h(v)]),
+	viewInfo: (handle) => {
+		const info = defaultOperations.viewInfo(raw(handle));
+		return { ...info, buffer: h(info.buffer) };
+	},
+	arrayBuffer: (handle) => raw(handle),
+	arrayLength: (handle) => raw(handle).length,
+	hasOwnIndex: (handle, index) => Object.hasOwn(raw(handle), index),
+	arrayIndices: (handle) => defaultOperations.arrayIndices(raw(handle)),
+	objectShape: (handle) => defaultOperations.objectShape(raw(handle)),
+	get: (handle, key) => h(raw(handle)[key])
+};
+
+suite('handle-based operations', (test) => {
+	/** @param {any} value */
+	function assert_parity(value) {
+		assert.equal(
+			stringify(h(value), undefined, { operations: handle_operations }),
+			stringify(value)
+		);
+	}
+
+	test('primitives', () => {
+		assert_parity(42);
+		assert_parity(-0);
+		assert_parity(NaN);
+		assert_parity(Infinity);
+		assert_parity('hello');
+		assert_parity(true);
+		assert_parity(null);
+		assert_parity(undefined);
+		assert_parity(123n);
+	});
+
+	test('objects, arrays and special types', () => {
+		assert_parity({ a: 1, nested: { b: [2, 3] } });
+		assert_parity([1, 'two', { three: 3 }]);
+		assert_parity(new Date(1700000000000));
+		assert_parity(/ab+c/gi);
+		assert_parity(new Map([['k', { v: 1 }]]));
+		assert_parity(new Set([1, 2, 3]));
+		assert_parity(new URL('https://example.com/path?q=1'));
+		// eslint-disable-next-line no-sparse-arrays
+		assert_parity([1, , 3]);
+		assert_parity(Object.assign(Object.create(null), { x: 1 }));
+		assert_parity(new Number(42));
+	});
+
+	test('typed arrays and buffers', () => {
+		const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+		assert_parity(buffer);
+		assert_parity(new Uint8Array(buffer));
+		assert_parity(new Int16Array(buffer, 2, 2)); // subarray
+		assert_parity(new DataView(buffer, 1, 4));
+	});
+
+	test('repeated references deduplicate via identify despite distinct handles', () => {
+		const shared = { x: 1 };
+		const value = { first: shared, second: shared };
+
+		// every property access creates a *fresh* Handle, so without
+		// identify-based keying the two handles would serialize twice
+		const result = stringify(h(value), undefined, { operations: handle_operations });
+
+		assert.equal(result, stringify(value));
+
+		const parsed = parse(result);
+		assert.equal(parsed.first, parsed.second);
+	});
+
+	test('cyclic values', () => {
+		/** @type {any} */
+		const cyclic = { name: 'cycle' };
+		cyclic.self = cyclic;
+
+		const result = stringify(h(cyclic), undefined, { operations: handle_operations });
+
+		assert.equal(result, stringify(cyclic));
+
+		const parsed = parse(result);
+		assert.equal(parsed.self, parsed);
+	});
+
+	test('reducers receive the handle, not the raw value', () => {
+		class Custom {
+			constructor(inner) {
+				this.inner = inner;
+			}
+		}
+
+		const result = stringify(h(new Custom('yes')), {
+			Custom: (handle) =>
+				handle instanceof Handle && raw(handle) instanceof Custom
+					? h(raw(handle).inner)
+					: false
+		}, { operations: handle_operations });
+
+		assert.equal(result, '[["Custom",1],"yes"]');
+	});
+
+	test('async: thenables resolve through resolveThenable', async () => {
+		const value = { result: Promise.resolve({ deep: Promise.resolve(42) }) };
+
+		const [expected, actual] = await Promise.all([
+			stringifyAsync(value),
+			stringifyAsync(h(value), undefined, { operations: handle_operations })
+		]);
+
+		assert.equal(actual, expected);
+	});
+
+	test('temporal values', () => {
+		assert_parity(Temporal.Instant.from('2023-11-14T22:13:20Z'));
+		assert_parity(Temporal.PlainDate.from('2023-11-14'));
+	});
+});

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -57,6 +57,37 @@ suite('operations option', (test) => {
 		assert.equal(result, stringify({ a: 1, date: new Date(1700000000000) }));
 	});
 
+	test('nullish overrides fall back to defaults', () => {
+		const value = { a: 1, date: new Date(1700000000000) };
+
+		const result = stringify(value, undefined, {
+			operations: {
+				get: undefined,
+				// @ts-expect-error null is not a valid override, but coalesces
+				dateISO: null,
+				tag: (thing) => defaultOperations.tag(thing)
+			}
+		});
+
+		assert.equal(result, stringify(value));
+	});
+
+	test('inherited operation members are picked up', () => {
+		// an operations object need not own its members — e.g. a class instance
+		class Operations {
+			/** @param {any} value */
+			dateISO(value) {
+				return `custom:${value.getTime()}`;
+			}
+		}
+
+		const result = stringify(new Date(1700000000000), undefined, {
+			operations: new Operations()
+		});
+
+		assert.equal(result, '[["Date","custom:1700000000000"]]');
+	});
+
 	test('defaultOperations and objectShape sentinels are frozen', () => {
 		assert.ok(Object.isFrozen(defaultOperations));
 		assert.ok(Object.isFrozen(defaultOperations.objectShape(new Map())));
@@ -310,7 +341,7 @@ const handle_operations = {
 	primitive: (handle) => raw(handle),
 	tag: (handle) => defaultOperations.tag(raw(handle)),
 	isThenable: (handle) => typeof raw(handle).then === 'function',
-	resolveThenable: (handle) => Promise.resolve(raw(handle)).then(h),
+	toPromise: (handle) => Promise.resolve(raw(handle)).then(h),
 	unbox: (handle) => h(raw(handle).valueOf()),
 	dateISO: (handle) => defaultOperations.dateISO(raw(handle)),
 	toStringValue: (handle) => raw(handle).toString(),
@@ -323,7 +354,7 @@ const handle_operations = {
 	},
 	arrayBuffer: (handle) => raw(handle),
 	arrayLength: (handle) => raw(handle).length,
-	hasOwnIndex: (handle, index) => Object.hasOwn(raw(handle), index),
+	hasOwn: (handle, index) => Object.hasOwn(raw(handle), index),
 	arrayIndices: (handle) => defaultOperations.arrayIndices(raw(handle)),
 	objectShape: (handle) => defaultOperations.objectShape(raw(handle)),
 	get: (handle, key) => h(raw(handle)[key])
@@ -416,7 +447,7 @@ suite('handle-based operations', (test) => {
 		assert.equal(result, '[["Custom",1],"yes"]');
 	});
 
-	test('async: thenables resolve through resolveThenable', async () => {
+	test('async: thenables resolve through toPromise', async () => {
 		const value = { result: Promise.resolve({ deep: Promise.resolve(42) }) };
 
 		const [expected, actual] = await Promise.all([

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -519,10 +519,14 @@ function tripwire(value) {
 		handler[trap] = (_target, ...args) => {
 			// When a promise fulfills with an object, the ECMAScript promise
 			// resolution procedure reads `.then` on it — that is the engine,
-			// not the serializer, and no operations implementation can prevent
-			// it. Tolerate it (the proxy absorbs the read; the underlying value
-			// is never touched), but count it so tests can assert it only
-			// happens on async paths.
+			// not the serializer. `toPromise` could sidestep this by fulfilling
+			// with an inert (non-proxy) handle, but an inert handle cannot
+			// observe reads, and the handle is exactly the object a stray
+			// direct touch in stringify.js would land on — so wrapping it in
+			// the tripwire is what gives the suite its teeth on async paths.
+			// The engine probe is the one read that then cannot be prevented:
+			// absorb it (the underlying value is never touched) and count it,
+			// so tests can assert exactly when it occurs.
 			if (trap === 'get' && args[0] === 'then') {
 				tripwire_then_probes += 1;
 				return undefined;

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -463,3 +463,218 @@ suite('handle-based operations', (test) => {
 		assert_parity(Temporal.PlainDate.from('2023-11-14'));
 	});
 });
+
+// ---------------------------------------------------------------------------
+// The value is never touched directly
+// ---------------------------------------------------------------------------
+
+// Executable proof of the core claim of custom operations: with a complete
+// implementation, the stringify algorithm never touches the value being
+// serialized — every introspection goes through the operations. Values are
+// wrapped in "tripwire" proxies whose every trap records a violation and
+// throws; the operations unwrap through a WeakMap side-channel, so any direct
+// touch (a stray `thing.foo` in stringify.js) trips instantly with the trap
+// name and key.
+
+/** @type {WeakMap<object, any>} */
+const tripwire_targets = new WeakMap();
+
+/** @type {string[]} */
+let tripwire_violations = [];
+
+/** engine-level `.then` reads from the promise resolution procedure */
+let tripwire_then_probes = 0;
+
+const TRIPWIRE_TRAPS = /** @type {const} */ ([
+	'apply',
+	'construct',
+	'defineProperty',
+	'deleteProperty',
+	'get',
+	'getOwnPropertyDescriptor',
+	'getPrototypeOf',
+	'has',
+	'isExtensible',
+	'ownKeys',
+	'preventExtensions',
+	'set',
+	'setPrototypeOf'
+]);
+
+/**
+ * Wraps an object in a proxy that records + throws on every trap.
+ * Primitives are returned as-is (they cannot be touched).
+ * @param {any} value
+ */
+function tripwire(value) {
+	if (value === null || (typeof value !== 'object' && typeof value !== 'function')) {
+		return value;
+	}
+
+	/** @type {ProxyHandler<any>} */
+	const handler = {};
+
+	for (const trap of TRIPWIRE_TRAPS) {
+		// @ts-expect-error dynamic trap definition
+		handler[trap] = (_target, ...args) => {
+			// When a promise fulfills with an object, the ECMAScript promise
+			// resolution procedure reads `.then` on it — that is the engine,
+			// not the serializer, and no operations implementation can prevent
+			// it. Tolerate it (the proxy absorbs the read; the underlying value
+			// is never touched), but count it so tests can assert it only
+			// happens on async paths.
+			if (trap === 'get' && args[0] === 'then') {
+				tripwire_then_probes += 1;
+				return undefined;
+			}
+
+			const detail =
+				typeof args[0] === 'string' || typeof args[0] === 'symbol'
+					? ` (${String(args[0])})`
+					: '';
+			tripwire_violations.push(trap + detail);
+			throw new Error(`value touched directly: ${trap}${detail}`);
+		};
+	}
+
+	const proxy = new Proxy(value, handler);
+	tripwire_targets.set(proxy, value);
+	return proxy;
+}
+
+/** @param {any} value */
+const untrip = (value) => (tripwire_targets.has(value) ? tripwire_targets.get(value) : value);
+
+/**
+ * A complete operations implementation that only ever consults the WeakMap —
+ * never the proxy. Every recursively-serialized value is re-wrapped in a
+ * fresh tripwire so nested objects are protected too.
+ *
+ * @type {import('../src/types.js').StringifyOperations}
+ */
+const tripwire_operations = {
+	identify: (value) => untrip(value),
+	typeOf: (value) => {
+		const raw = untrip(value);
+		return raw === null ? 'null' : typeof raw;
+	},
+	primitive: (value) => untrip(value),
+	tag: (value) => defaultOperations.tag(untrip(value)),
+	isThenable: (value) => typeof untrip(value).then === 'function',
+	toPromise: (value) => Promise.resolve(untrip(value)).then(tripwire),
+	unbox: (value) => tripwire(untrip(value).valueOf()),
+	dateISO: (value) => defaultOperations.dateISO(untrip(value)),
+	toStringValue: (value) => untrip(value).toString(),
+	regExp: (value) => defaultOperations.regExp(untrip(value)),
+	setValues: (value) => [...untrip(value)].map(tripwire),
+	mapEntries: (value) => [...untrip(value)].map(([k, v]) => [tripwire(k), tripwire(v)]),
+	viewInfo: (value) => {
+		const info = defaultOperations.viewInfo(untrip(value));
+		return { ...info, buffer: tripwire(info.buffer) };
+	},
+	arrayBuffer: (value) => untrip(value),
+	arrayLength: (value) => untrip(value).length,
+	hasOwn: (value, key) => Object.hasOwn(untrip(value), key),
+	arrayIndices: (value) => defaultOperations.arrayIndices(untrip(value)),
+	objectShape: (value) => defaultOperations.objectShape(untrip(value)),
+	get: (value, key) => tripwire(untrip(value)[key])
+};
+
+suite('tripwire operations (value is never touched)', (test) => {
+	/** @param {any} value */
+	function assert_untouched(value) {
+		tripwire_violations = [];
+		tripwire_then_probes = 0;
+
+		const result = stringify(tripwire(value), undefined, {
+			operations: tripwire_operations
+		});
+
+		assert.equal(tripwire_violations, [], `traps fired: ${tripwire_violations.join(', ')}`);
+		assert.equal(tripwire_then_probes, 0, 'sync serialization must never read .then');
+		assert.equal(result, stringify(value), 'output parity');
+	}
+
+	test('sync serialization never touches the value', () => {
+		const shared = { x: 1 };
+
+		/** @type {any} */
+		const cyclic = { name: 'cycle' };
+		cyclic.self = cyclic;
+
+		const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+
+		const sparse = [];
+		sparse[100] = 'x';
+
+		assert_untouched({ a: 1, nested: { b: [2, 3] }, first: shared, second: shared });
+		// eslint-disable-next-line no-sparse-arrays
+		assert_untouched([1, 'two', { three: 3 }, , 5]);
+		assert_untouched(sparse);
+		assert_untouched(new Date(1700000000000));
+		assert_untouched(/ab+c/gi);
+		assert_untouched(new Map([['k', { v: 1 }], [shared, shared]]));
+		assert_untouched(new Set([1, { two: 2 }]));
+		assert_untouched(new URL('https://example.com/?q=1'));
+		assert_untouched(Object.assign(Object.create(null), { x: 1 }));
+		assert_untouched(new Number(42));
+		assert_untouched(new String('boxed'));
+		assert_untouched(buffer);
+		assert_untouched(new Uint8Array(buffer));
+		assert_untouched(new Int16Array(buffer, 2, 2));
+		assert_untouched(new DataView(buffer, 1, 4));
+		assert_untouched(cyclic);
+	});
+
+	test('async serialization only incurs engine-level .then reads on the proxy', async () => {
+		tripwire_violations = [];
+		tripwire_then_probes = 0;
+
+		const value = { p: Promise.resolve({ deep: Promise.resolve(42) }) };
+
+		const result = await stringifyAsync(tripwire(value), undefined, {
+			operations: tripwire_operations
+		});
+
+		assert.equal(tripwire_violations, [], `traps fired: ${tripwire_violations.join(', ')}`);
+		// exactly one: the promise resolution procedure reading .then on the
+		// (re-wrapped) object that `p` fulfills with — absorbed by the proxy,
+		// never reaching the underlying value. `42` is a primitive, so the
+		// inner promise adds none.
+		assert.equal(tripwire_then_probes, 1);
+		assert.equal(result, await stringifyAsync(value));
+	});
+
+	test('reducers receive the untouched proxy', () => {
+		class Custom {
+			/** @param {any} inner */
+			constructor(inner) {
+				this.inner = inner;
+			}
+		}
+
+		tripwire_violations = [];
+		tripwire_then_probes = 0;
+
+		const result = stringify(
+			tripwire(new Custom('yes')),
+			{
+				Custom: (value) =>
+					untrip(value) instanceof Custom && tripwire({ inner: untrip(value).inner })
+			},
+			{ operations: tripwire_operations }
+		);
+
+		assert.equal(tripwire_violations, []);
+		assert.equal(parse(result, { Custom: (value) => value }).inner, 'yes');
+	});
+
+	test('negative control: default operations trip the wire', () => {
+		// proves the tripwire actually detects touches — without it, the other
+		// tests would pass vacuously
+		tripwire_violations = [];
+
+		assert.throws(() => stringify(tripwire({ a: 1 })), /value touched directly/);
+		assert.ok(tripwire_violations.length > 0);
+	});
+});

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -48,8 +48,8 @@ suite('operations option', (test) => {
 			{
 				operations: {
 					get: undefined,
-					dateISO: undefined,
-					tag: (value) => defaultOperations.tag(value)
+					toISOString: undefined,
+					tagOf: (value) => defaultOperations.tagOf(value)
 				}
 			}
 		);
@@ -64,8 +64,8 @@ suite('operations option', (test) => {
 			operations: {
 				get: undefined,
 				// @ts-expect-error null is not a valid override, but coalesces
-				dateISO: null,
-				tag: (thing) => defaultOperations.tag(thing)
+				toISOString: null,
+				tagOf: (thing) => defaultOperations.tagOf(thing)
 			}
 		});
 
@@ -76,7 +76,7 @@ suite('operations option', (test) => {
 		// an operations object need not own its members — e.g. a class instance
 		class Operations {
 			/** @param {any} value */
-			dateISO(value) {
+			toISOString(value) {
 				return `custom:${value.getTime()}`;
 			}
 		}
@@ -88,18 +88,18 @@ suite('operations option', (test) => {
 		assert.equal(result, '[["Date","custom:1700000000000"]]');
 	});
 
-	test('defaultOperations and objectShape sentinels are frozen', () => {
+	test('defaultOperations and shapeOf sentinels are frozen', () => {
 		assert.ok(Object.isFrozen(defaultOperations));
-		assert.ok(Object.isFrozen(defaultOperations.objectShape(new Map())));
+		assert.ok(Object.isFrozen(defaultOperations.shapeOf(new Map())));
 		assert.ok(
-			Object.isFrozen(defaultOperations.objectShape({ [Symbol('key')]: 1 }))
+			Object.isFrozen(defaultOperations.shapeOf({ [Symbol('key')]: 1 }))
 		);
 	});
 
 	test('defaultOperations is exported and delegable', () => {
 		const result = stringify(new Map([['k', 'v']]), undefined, {
 			operations: {
-				mapEntries: (value) => defaultOperations.mapEntries(value)
+				entriesOf: (value) => defaultOperations.entriesOf(value)
 			}
 		});
 
@@ -119,17 +119,17 @@ suite('operations option', (test) => {
 		const a = new Wrapper(shared);
 		const b = new Wrapper(shared);
 
-		/** @type {import('../src/types.js').StringifyOperations['objectShape']} */
-		const objectShape = (value) =>
+		/** @type {import('../src/types.js').StringifyOperations['shapeOf']} */
+		const shapeOf = (value) =>
 			value instanceof Wrapper
-				? defaultOperations.objectShape(value.inner)
-				: defaultOperations.objectShape(value);
+				? defaultOperations.shapeOf(value.inner)
+				: defaultOperations.shapeOf(value);
 
 		const result = stringify([a, b], undefined, {
 			operations: {
 				identify: (value) => (value instanceof Wrapper ? value.inner : value),
-				tag: (value) => (value instanceof Wrapper ? 'Object' : defaultOperations.tag(value)),
-				objectShape,
+				tagOf: (value) => (value instanceof Wrapper ? 'Object' : defaultOperations.tagOf(value)),
+				shapeOf,
 				get: (value, key) =>
 					value instanceof Wrapper ? value.inner[key] : value[key]
 			}
@@ -145,7 +145,7 @@ suite('operations option', (test) => {
 // ---------------------------------------------------------------------------
 
 suite('side-effect-free operations', (test) => {
-	test('dateISO override avoids patched Date.prototype.toISOString', () => {
+	test('toISOString override avoids patched Date.prototype.toISOString', () => {
 		const original = Date.prototype.toISOString;
 		let patched_calls = 0;
 		// eslint-disable-next-line no-extend-native
@@ -164,7 +164,7 @@ suite('side-effect-free operations', (test) => {
 			// hardened ops use a captured intrinsic
 			const result = stringify(date, undefined, {
 				operations: {
-					dateISO: (value) => original.call(value)
+					toISOString: (value) => original.call(value)
 				}
 			});
 
@@ -176,7 +176,7 @@ suite('side-effect-free operations', (test) => {
 		}
 	});
 
-	test('mapEntries/setValues overrides avoid patched Symbol.iterator', () => {
+	test('entriesOf/valuesOf overrides avoid patched Symbol.iterator', () => {
 		const map_entries = Map.prototype.entries;
 		const set_values = Set.prototype.values;
 		const map_iterator = Map.prototype[Symbol.iterator];
@@ -197,8 +197,8 @@ suite('side-effect-free operations', (test) => {
 
 			const result = stringify(value, undefined, {
 				operations: {
-					mapEntries: (map) => map_entries.call(map),
-					setValues: (set) => set_values.call(set)
+					entriesOf: (map) => map_entries.call(map),
+					valuesOf: (set) => set_values.call(set)
 				}
 			});
 
@@ -210,7 +210,7 @@ suite('side-effect-free operations', (test) => {
 		}
 	});
 
-	test('tag override is not fooled by Symbol.toStringTag getters', () => {
+	test('tagOf override is not fooled by Symbol.toStringTag getters', () => {
 		let getter_calls = 0;
 
 		const sneaky = {};
@@ -232,7 +232,7 @@ suite('side-effect-free operations', (test) => {
 		// hardened ops use brand checks — here simplified to "trust nothing"
 		const result = stringify(sneaky, undefined, {
 			operations: {
-				tag: (value) => {
+				tagOf: (value) => {
 					if (value instanceof Date) return 'Date';
 					if (Array.isArray(value)) return 'Array';
 					return 'Object';
@@ -291,7 +291,7 @@ suite('side-effect-free operations', (test) => {
 		stringify(trap, undefined, {
 			operations: {
 				isThenable: (value) => value instanceof Promise,
-				objectShape: (value) => ({
+				shapeOf: (value) => ({
 					kind: 'plain',
 					keys: Object.keys(value)
 				})
@@ -338,25 +338,25 @@ const handle_operations = {
 		const value = raw(handle);
 		return value === null ? 'null' : typeof value;
 	},
-	primitive: (handle) => raw(handle),
-	tag: (handle) => defaultOperations.tag(raw(handle)),
+	toPrimitive: (handle) => raw(handle),
+	tagOf: (handle) => defaultOperations.tagOf(raw(handle)),
 	isThenable: (handle) => typeof raw(handle).then === 'function',
 	toPromise: (handle) => Promise.resolve(raw(handle)).then(h),
 	unbox: (handle) => h(raw(handle).valueOf()),
-	dateISO: (handle) => defaultOperations.dateISO(raw(handle)),
+	toISOString: (handle) => defaultOperations.toISOString(raw(handle)),
 	toStringValue: (handle) => raw(handle).toString(),
-	regExp: (handle) => defaultOperations.regExp(raw(handle)),
-	setValues: (handle) => [...raw(handle)].map(h),
-	mapEntries: (handle) => [...raw(handle)].map(([k, v]) => [h(k), h(v)]),
+	regExpInfo: (handle) => defaultOperations.regExpInfo(raw(handle)),
+	valuesOf: (handle) => [...raw(handle)].map(h),
+	entriesOf: (handle) => [...raw(handle)].map(([k, v]) => [h(k), h(v)]),
 	viewInfo: (handle) => {
 		const info = defaultOperations.viewInfo(raw(handle));
 		return { ...info, buffer: h(info.buffer) };
 	},
-	arrayBuffer: (handle) => raw(handle),
-	arrayLength: (handle) => raw(handle).length,
+	toArrayBuffer: (handle) => raw(handle),
+	lengthOf: (handle) => raw(handle).length,
 	hasOwn: (handle, index) => Object.hasOwn(raw(handle), index),
-	arrayIndices: (handle) => defaultOperations.arrayIndices(raw(handle)),
-	objectShape: (handle) => defaultOperations.objectShape(raw(handle)),
+	indicesOf: (handle) => defaultOperations.indicesOf(raw(handle)),
+	shapeOf: (handle) => defaultOperations.shapeOf(raw(handle)),
 	get: (handle, key) => h(raw(handle)[key])
 };
 
@@ -562,25 +562,25 @@ const tripwire_operations = {
 		const raw = untrip(value);
 		return raw === null ? 'null' : typeof raw;
 	},
-	primitive: (value) => untrip(value),
-	tag: (value) => defaultOperations.tag(untrip(value)),
+	toPrimitive: (value) => untrip(value),
+	tagOf: (value) => defaultOperations.tagOf(untrip(value)),
 	isThenable: (value) => typeof untrip(value).then === 'function',
 	toPromise: (value) => Promise.resolve(untrip(value)).then(tripwire),
 	unbox: (value) => tripwire(untrip(value).valueOf()),
-	dateISO: (value) => defaultOperations.dateISO(untrip(value)),
+	toISOString: (value) => defaultOperations.toISOString(untrip(value)),
 	toStringValue: (value) => untrip(value).toString(),
-	regExp: (value) => defaultOperations.regExp(untrip(value)),
-	setValues: (value) => [...untrip(value)].map(tripwire),
-	mapEntries: (value) => [...untrip(value)].map(([k, v]) => [tripwire(k), tripwire(v)]),
+	regExpInfo: (value) => defaultOperations.regExpInfo(untrip(value)),
+	valuesOf: (value) => [...untrip(value)].map(tripwire),
+	entriesOf: (value) => [...untrip(value)].map(([k, v]) => [tripwire(k), tripwire(v)]),
 	viewInfo: (value) => {
 		const info = defaultOperations.viewInfo(untrip(value));
 		return { ...info, buffer: tripwire(info.buffer) };
 	},
-	arrayBuffer: (value) => untrip(value),
-	arrayLength: (value) => untrip(value).length,
+	toArrayBuffer: (value) => untrip(value),
+	lengthOf: (value) => untrip(value).length,
 	hasOwn: (value, key) => Object.hasOwn(untrip(value), key),
-	arrayIndices: (value) => defaultOperations.arrayIndices(untrip(value)),
-	objectShape: (value) => defaultOperations.objectShape(untrip(value)),
+	indicesOf: (value) => defaultOperations.indicesOf(untrip(value)),
+	shapeOf: (value) => defaultOperations.shapeOf(untrip(value)),
 	get: (value, key) => tripwire(untrip(value)[key])
 };
 


### PR DESCRIPTION
## Summary

Adds an optional third argument to `stringify`/`stringifyAsync`:

```js
stringify(value, reducers, { operations: { /* Partial<StringifyOperations> */ } })
```

Every introspection the serializer performs on the value — property reads, prototype method calls, iteration, type classification — now routes through a `StringifyOperations` interface. Omitted members fall back to `defaultOperations` (newly exported), which are the current behavior extracted verbatim, so **the default path is unchanged**.

## Motivation

Two use cases, both real (we're building on them for Vercel's Workflow SDK, which uses devalue at the core of its durable-execution serialization):

1. **Side-effect-free serialization.** Today, serializing a value can execute user code in ways that are surprising and, for deterministic-replay runtimes, corrupting:
   - `thing[key]` fires getters and proxy traps
   - `Object.prototype.toString` (type classification) reads `Symbol.toStringTag`, which can be a getter — user code runs and the brand is spoofable
   - `thing.toISOString()`, `thing.valueOf()`, `Map.prototype[Symbol.iterator]`, `.source`/`.flags`/`.buffer`/`.byteLength` etc. all dispatch through patchable prototypes
   - `typeof thing.then` triggers `then` getters

   With this change, a caller can override exactly the risky operations with implementations based on captured intrinsics, internal-slot brand checks, and property descriptors — making `stringify` provably side-effect free for their values.

2. **Foreign-runtime serialization.** The algorithm never touches the value directly anymore, so "value" can be an opaque handle to something in another JS runtime (a `node:vm` context, a WASM-hosted engine, a remote process). The new `identify` operation keys deduplication/cycle detection on the underlying value's identity rather than the handle's, so two distinct handles to one object still serialize as one reference.

## Design notes

- **API shape**: an options object (`{ operations }`) rather than a positional bag, leaving room for future options
- **Granularity**: mostly one operation per brand (`dateISO`, `regExp`, `mapEntries`, `viewInfo`, …) so overrides are small; the plain-object path is a single coarse `objectShape` call (classification + keys in one crossing, which matters for WASM-boundary implementations)
- **Reducers are untouched** — they receive the raw value/handle exactly as before, and their return values are serialized through the same operations
- `uneval` and `parse` are deliberately out of scope

## Tests

16 new tests in `test/operations.test.js` (760 total passing):

- default-path equivalence and partial-override merging
- side-effect-free suite: spy-patched `Date.prototype.toISOString`, `Map/Set.prototype[Symbol.iterator]`, `Symbol.toStringTag` getter, object getters, `.then` getter — asserting zero invocations under overridden ops
- a complete handle-model implementation (`Handle` wrapper + full ops): output parity with plain `stringify` across primitives, POJOs, null-proto objects, sparse arrays, Map/Set, Date/RegExp/URL/Temporal, typed-array subarrays, DataView, cycles, dedup-through-distinct-handles, reducers, and async thenables

## Performance

Existing benchmark suite (typed arrays — covers the hottest refactored paths), before/after on the same machine:

| | baseline (ms) | this PR (ms) |
|---|---|---|
| stringify: small | 192.09 | 187.47 |
| stringify: medium | 12.03 | 9.68 |
| stringify: large | 14.58 | 9.98 |
| suite total | 569.29 | 546.09 |

No regression (differences within noise). Call sites remain monomorphic — when no `operations` are passed, the shared `default_operations` object is used directly.