### PR TITLE
feat: pluggable operations for parse

### DIFF
--- a/.changeset/filter-array-indices.md
+++ b/.changeset/filter-array-indices.md
@@ -2,4 +2,4 @@
 'devalue': minor
 ---
 
-feat: export `filterArrayIndices`, the array-index filtering used by the `arrayIndices` stringify operation, so custom operations can reuse it instead of reimplementing it
+feat: export `filterArrayIndices`, the array-index filtering used by the `indicesOf` stringify operation, so custom operations can reuse it instead of reimplementing it

--- a/.changeset/filter-array-indices.md
+++ b/.changeset/filter-array-indices.md
@@ -1,0 +1,5 @@
+---
+'devalue': minor
+---
+
+feat: export `filterArrayIndices`, the array-index filtering used by the `arrayIndices` stringify operation, so custom operations can reuse it instead of reimplementing it

--- a/.changeset/pluggable-parse-operations.md
+++ b/.changeset/pluggable-parse-operations.md
@@ -1,0 +1,5 @@
+---
+'devalue': minor
+---
+
+feat: add pluggable `operations` option to `parse`/`unflatten`, allowing customization of how values are constructed while reviving (e.g. cross-realm or foreign-runtime revival)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ const stringified = devalue.stringify(rootHandle, undefined, {
 });
 ```
 
+Some operations have a non-obvious contract that is easy to get subtly wrong. Where the work is not specific to your values, devalue exports the pieces so you don't have to reimplement them — `filterArrayIndices` does the array-index filtering that `indicesOf` needs, given keys you already have:
+
+```js
+indicesOf: (handle) => devalue.filterArrayIndices(handle.ownEnumerableStringKeys())
+```
+
 Reducers compose with custom operations: they receive the raw value/handle, and whatever they return is serialized through the same operations.
 
 ### Customizing `parse`

--- a/README.md
+++ b/README.md
@@ -186,6 +186,39 @@ const stringified = devalue.stringify(rootHandle, undefined, {
 
 Reducers compose with custom operations: they receive the raw value/handle, and whatever they return is serialized through the same operations.
 
+### Customizing `parse`
+
+The mirror image: `parse` and `unflatten` build every value through construction operations (`ParseOperations`, defaults exported as `defaultParseOperations`), so you can control what gets created. The members mirror `StringifyOperations` with the host/value-space boundary running the other way: each `fromXxx` inverts the corresponding `toXxx`, `fromXxxInfo` inverts `xxxInfo`, and the bare-verb mutators invert the bare-verb accessors (`set`/`get`, `addValue`/`valuesOf`, `addEntry`/`entriesOf`, `box`/`unbox`).
+
+**Cross-realm revival.** By default the revived value is built from the intrinsics of whichever realm devalue is running in, so `instanceof` checks fail elsewhere. Constructing from a target realm's intrinsics fixes that:
+
+```js
+const revived = devalue.parse(serialized, undefined, {
+	operations: {
+		fromISOString: (iso) => new sandbox.Date(iso),
+		createMap: () => new sandbox.Map(),
+		createObject: () => sandbox.makeObject()
+	}
+});
+```
+
+**Foreign-runtime revival.** `parse` never inspects the values it creates — it only passes them back into other operations — so the operations can build values inside another runtime and return opaque handles:
+
+```js
+const rootHandle = devalue.parse(serialized, undefined, {
+	operations: {
+		fromPrimitive: (value) => vm.toHandle(value),
+		createObject: () => vm.newObject(),
+		set: (handle, key, value) => handle.setProp(key, value)
+		// ... see ParseOperations for the full interface
+	}
+});
+```
+
+Containers are created empty and populated afterwards (`createMap` then `addEntry`, `createObject` then `set`, and so on) — that ordering is what allows cyclic values to be revived, since the empty container is cached before its contents are built.
+
+Revivers compose the same way reducers do: they receive whatever the operations built, and their return value is used as-is.
+
 ## Error handling
 
 If `uneval` or `stringify` encounters a function or a non-POJO that isn't handled by a custom replacer/reducer, it will throw an error. You can find where in the input data the offending value lives by inspecting `error.path`:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Note that any variables referenced in the resulting JavaScript (like `Vector` in
 
 ## Custom operations
 
-Every introspection `stringify` performs on the value being serialized — property reads, prototype method calls, iteration, type classification — goes through an operations interface that you can override via the `operations` option. Omitted members fall back to the defaults (exported as `defaultOperations`), which behave exactly as devalue always has.
+Every introspection `stringify` performs on the value being serialized — property reads, prototype method calls, iteration, type classification — goes through an operations interface that you can override via the `operations` option. Omitted members fall back to the defaults (exported as `defaultStringifyOperations`), which behave exactly as devalue always has.
 
 This is useful in two situations:
 
@@ -213,7 +213,7 @@ const revived = devalue.parse(serialized, undefined, {
 ```js
 const rootHandle = devalue.parse(serialized, undefined, {
 	operations: {
-		fromPrimitive: (value) => vm.toHandle(value),
+		fromPrimitive: (primitive) => vm.toHandle(primitive),
 		createObject: () => vm.newObject(),
 		set: (handle, key, value) => handle.setProp(key, value)
 		// ... see ParseOperations for the full interface

--- a/index.js
+++ b/index.js
@@ -2,12 +2,16 @@ export { uneval } from './src/uneval.js';
 export { parse, unflatten } from './src/parse.js';
 export { stringify, stringifyAsync } from './src/stringify.js';
 export {
-	default_operations as defaultOperations,
+	default_stringify_operations as defaultStringifyOperations,
 	default_parse_operations as defaultParseOperations
 } from './src/operations.js';
 export { DevalueError, filter_array_indices as filterArrayIndices } from './src/utils.js';
 
+/** @typedef {import('./src/types.js').StringValueTag} StringValueTag */
+/** @typedef {import('./src/types.js').ViewTag} ViewTag */
 /** @typedef {import('./src/types.js').StringifyOperations} StringifyOperations */
+/** @typedef {import('./src/types.js').DefaultStringifyOperations} DefaultStringifyOperations */
 /** @typedef {import('./src/types.js').StringifyOptions} StringifyOptions */
 /** @typedef {import('./src/types.js').ParseOperations} ParseOperations */
+/** @typedef {import('./src/types.js').DefaultParseOperations} DefaultParseOperations */
 /** @typedef {import('./src/types.js').ParseOptions} ParseOptions */

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ export {
 	default_operations as defaultOperations,
 	default_parse_operations as defaultParseOperations
 } from './src/operations.js';
-export { DevalueError } from './src/utils.js';
+export { DevalueError, filter_array_indices as filterArrayIndices } from './src/utils.js';
 
 /** @typedef {import('./src/types.js').StringifyOperations} StringifyOperations */
 /** @typedef {import('./src/types.js').StringifyOptions} StringifyOptions */

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
 export { uneval } from './src/uneval.js';
 export { parse, unflatten } from './src/parse.js';
 export { stringify, stringifyAsync } from './src/stringify.js';
-export { default_operations as defaultOperations } from './src/operations.js';
+export {
+	default_operations as defaultOperations,
+	default_parse_operations as defaultParseOperations
+} from './src/operations.js';
 export { DevalueError } from './src/utils.js';
 
 /** @typedef {import('./src/types.js').StringifyOperations} StringifyOperations */
 /** @typedef {import('./src/types.js').StringifyOptions} StringifyOptions */
+/** @typedef {import('./src/types.js').ParseOperations} ParseOperations */
+/** @typedef {import('./src/types.js').ParseOptions} ParseOptions */

--- a/src/operations.js
+++ b/src/operations.js
@@ -49,9 +49,9 @@ const SYMBOL_KEYS = Object.freeze({ kind: 'symbol-keys' });
  * The object is frozen — it is shared by every `stringify` call that does
  * not override a given operation.
  *
- * @type {import('./types.js').StringifyOperations}
  */
-export const default_operations = Object.freeze({
+/** @type {import('./types.js').DefaultStringifyOperations} */
+const stringify_operations = {
 	identify: (value) => value,
 
 	typeOf: (value) => (value === null ? 'null' : typeof value),
@@ -103,7 +103,9 @@ export const default_operations = Object.freeze({
 	},
 
 	get: (value, key) => value[key]
-});
+};
+
+export const default_stringify_operations = Object.freeze(stringify_operations);
 
 /**
  * The default implementations of every construction operation `parse` and
@@ -119,10 +121,10 @@ export const default_operations = Object.freeze({
  * The object is frozen — it is shared by every `parse` call that does not
  * override a given operation.
  *
- * @type {import('./types.js').ParseOperations}
  */
-export const default_parse_operations = Object.freeze({
-	fromPrimitive: (value) => value,
+/** @type {import('./types.js').DefaultParseOperations} */
+const parse_operations = {
+	fromPrimitive: (primitive) => primitive,
 
 	fromISOString: (iso) => new Date(iso),
 
@@ -138,8 +140,8 @@ export const default_parse_operations = Object.freeze({
 
 	fromRegExpInfo: (source, flags) => new RegExp(source, flags),
 
-	fromViewInfo: (type, buffer, byteOffset, length) => {
-		const Constructor = /** @type {any} */ (globalThis)[type];
+	fromViewInfo: (tag, buffer, byteOffset, length) => {
+		const Constructor = /** @type {any} */ (globalThis)[tag];
 		return byteOffset !== undefined
 			? new Constructor(buffer, byteOffset, length)
 			: new Constructor(buffer);
@@ -186,4 +188,6 @@ export const default_parse_operations = Object.freeze({
 	addEntry: (map, key, value) => {
 		map.set(key, value);
 	}
-});
+};
+
+export const default_parse_operations = Object.freeze(parse_operations);

--- a/src/operations.js
+++ b/src/operations.js
@@ -1,9 +1,33 @@
+import { MAX_ARRAY_INDEX } from './constants.js';
 import {
 	enumerable_symbols,
 	get_type,
 	is_plain_object,
 	valid_array_indices
 } from './utils.js';
+
+/**
+ * Merges caller-provided operation overrides over the defaults. Iterating the
+ * default keys (rather than the override's own keys) means nullish members
+ * fall back to the default, and inherited members — e.g. from a class
+ * instance — are picked up.
+ *
+ * @template {Record<string, any>} T
+ * @param {T} defaults
+ * @param {Partial<T> | undefined} overrides
+ * @returns {T}
+ */
+export function merge_operations(defaults, overrides) {
+	if (!overrides) return defaults;
+
+	const merged = /** @type {T} */ ({});
+
+	for (const key of /** @type {(keyof T)[]} */ (Object.keys(defaults))) {
+		merged[key] = overrides[key] ?? defaults[key];
+	}
+
+	return merged;
+}
 
 /** @type {{ kind: 'not-plain' }} */
 const NOT_PLAIN = Object.freeze({ kind: 'not-plain' });
@@ -79,4 +103,87 @@ export const default_operations = Object.freeze({
 	},
 
 	get: (value, key) => value[key]
+});
+
+/**
+ * The default implementations of every construction operation `parse` and
+ * `unflatten` perform while reviving a value. Each one uses native
+ * JavaScript semantics (built-in constructors, property assignment, etc).
+ *
+ * Pass overrides via the `operations` option of `parse`/`unflatten` to
+ * customize how values are built — e.g. to construct them from the
+ * intrinsics of a different realm (a `node:vm` context), or to build up
+ * values inside another JavaScript runtime (a WASM-hosted engine, a remote
+ * process) through handle objects.
+ *
+ * The object is frozen — it is shared by every `parse` call that does not
+ * override a given operation.
+ *
+ * @type {import('./types.js').ParseOperations}
+ */
+export const default_parse_operations = Object.freeze({
+	fromPrimitive: (value) => value,
+
+	fromISOString: (iso) => new Date(iso),
+
+	fromStringValue: (tag, text) => {
+		if (tag === 'URL') return new URL(text);
+		if (tag === 'URLSearchParams') return new URLSearchParams(text);
+		// 'Temporal.Instant', 'Temporal.PlainDate', ...
+		// @ts-expect-error TS doesn't know about Temporal yet
+		return Temporal[tag.slice(9)].from(text);
+	},
+
+	fromArrayBuffer: (buffer) => buffer,
+
+	fromRegExpInfo: (source, flags) => new RegExp(source, flags),
+
+	fromViewInfo: (type, buffer, byteOffset, length) => {
+		const Constructor = /** @type {any} */ (globalThis)[type];
+		return byteOffset !== undefined
+			? new Constructor(buffer, byteOffset, length)
+			: new Constructor(buffer);
+	},
+
+	box: (value) => Object(value),
+
+	createArray: (length) => new Array(length),
+
+	createSparseArray: (length) => {
+		/** @type {any[]} */
+		const array = [];
+
+		// Setting `array.length = length` (or equivalently calling
+		// `new Array(length)`) on an untrusted length is a DoS vector: V8
+		// eagerly allocates a contiguous backing store for array lengths below
+		// ~10^8, so a small payload with a huge declared length can force
+		// arbitrary memory allocation. Touching the largest-possible index
+		// first forces V8 into dictionary-elements mode, where `length` is
+		// just a number and no contiguous allocation occurs.
+		array[MAX_ARRAY_INDEX] = undefined;
+		delete array[MAX_ARRAY_INDEX];
+		array.length = length;
+
+		return array;
+	},
+
+	createObject: () => ({}),
+
+	createNullPrototypeObject: () => Object.create(null),
+
+	createSet: () => new Set(),
+
+	createMap: () => new Map(),
+
+	set: (target, key, value) => {
+		target[key] = value;
+	},
+
+	addValue: (set, value) => {
+		set.add(value);
+	},
+
+	addEntry: (map, key, value) => {
+		map.set(key, value);
+	}
 });

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,7 +1,6 @@
 import { decode64 } from './base64.js';
 import {
 	HOLE,
-	MAX_ARRAY_INDEX,
 	NAN,
 	NEGATIVE_INFINITY,
 	NEGATIVE_ZERO,
@@ -9,23 +8,29 @@ import {
 	SPARSE,
 	UNDEFINED
 } from './constants.js';
+import { default_parse_operations, merge_operations } from './operations.js';
 import { is_valid_array_index, is_valid_array_len } from './utils.js';
 
 /**
  * Revive a value serialized with `devalue.stringify`
  * @param {string} serialized
  * @param {Record<string, (value: any) => any>} [revivers]
+ * @param {import('./types.js').ParseOptions} [options]
  */
-export function parse(serialized, revivers) {
-	return unflatten(JSON.parse(serialized), revivers);
+export function parse(serialized, revivers, options) {
+	return unflatten(JSON.parse(serialized), revivers, options);
 }
 
 /**
  * Revive a value flattened with `devalue.stringify`
  * @param {number | any[]} parsed
  * @param {Record<string, (value: any) => any>} [revivers]
+ * @param {import('./types.js').ParseOptions} [options]
  */
-export function unflatten(parsed, revivers) {
+export function unflatten(parsed, revivers, options) {
+	/** @type {import('./types.js').ParseOperations} */
+	const ops = merge_operations(default_parse_operations, options?.operations);
+
 	if (typeof parsed === 'number') return hydrate(parsed, true);
 
 	if (!Array.isArray(parsed) || parsed.length === 0) {
@@ -48,11 +53,11 @@ export function unflatten(parsed, revivers) {
 	 * @returns {any}
 	 */
 	function hydrate(index, standalone = false) {
-		if (index === UNDEFINED) return undefined;
-		if (index === NAN) return NaN;
-		if (index === POSITIVE_INFINITY) return Infinity;
-		if (index === NEGATIVE_INFINITY) return -Infinity;
-		if (index === NEGATIVE_ZERO) return -0;
+		if (index === UNDEFINED) return ops.fromPrimitive(undefined);
+		if (index === NAN) return ops.fromPrimitive(NaN);
+		if (index === POSITIVE_INFINITY) return ops.fromPrimitive(Infinity);
+		if (index === NEGATIVE_INFINITY) return ops.fromPrimitive(-Infinity);
+		if (index === NEGATIVE_ZERO) return ops.fromPrimitive(-0);
 
 		if (standalone || typeof index !== 'number') {
 			throw new Error(`Invalid input`);
@@ -63,7 +68,7 @@ export function unflatten(parsed, revivers) {
 		const value = values[index];
 
 		if (!value || typeof value !== 'object') {
-			hydrated[index] = value;
+			hydrated[index] = ops.fromPrimitive(value);
 		} else if (Array.isArray(value)) {
 			if (typeof value[0] === 'string') {
 				const type = value[0];
@@ -103,27 +108,27 @@ export function unflatten(parsed, revivers) {
 
 				switch (type) {
 					case 'Date':
-						hydrated[index] = new Date(value[1]);
+						hydrated[index] = ops.fromISOString(value[1]);
 						break;
 
 					case 'Set':
-						const set = new Set();
+						const set = ops.createSet();
 						hydrated[index] = set;
 						for (let i = 1; i < value.length; i += 1) {
-							set.add(hydrate(value[i]));
+							ops.addValue(set, hydrate(value[i]));
 						}
 						break;
 
 					case 'Map':
-						const map = new Map();
+						const map = ops.createMap();
 						hydrated[index] = map;
 						for (let i = 1; i < value.length; i += 2) {
-							map.set(hydrate(value[i]), hydrate(value[i + 1]));
+							ops.addEntry(map, hydrate(value[i]), hydrate(value[i + 1]));
 						}
 						break;
 
 					case 'RegExp':
-						hydrated[index] = new RegExp(value[1], value[2]);
+						hydrated[index] = ops.fromRegExpInfo(value[1], value[2]);
 						break;
 
 					case 'Object': {
@@ -137,23 +142,23 @@ export function unflatten(parsed, revivers) {
 							throw new Error('Invalid input');
 						}
 
-						hydrated[index] = Object(hydrate(wrapped_index));
+						hydrated[index] = ops.box(hydrate(wrapped_index));
 						break;
 					}
 
 					case 'BigInt':
-						hydrated[index] = BigInt(value[1]);
+						hydrated[index] = ops.fromPrimitive(BigInt(value[1]));
 						break;
 
 					case 'null':
-						const obj = Object.create(null);
+						const obj = ops.createNullPrototypeObject();
 						hydrated[index] = obj;
 						for (let i = 1; i < value.length; i += 2) {
 							if (value[i] === '__proto__') {
 								throw new Error('Cannot parse an object with a `__proto__` property');
 							}
 
-							obj[value[i]] = hydrate(value[i + 1]);
+							ops.set(obj, value[i], hydrate(value[i + 1]));
 						}
 						break;
 
@@ -177,13 +182,9 @@ export function unflatten(parsed, revivers) {
 							throw new Error('Invalid data');
 						}
 
-						const TypedArrayConstructor = globalThis[type];
 						const buffer = hydrate(value[1]);
 
-						hydrated[index] =
-							value[2] !== undefined
-								? new TypedArrayConstructor(buffer, value[2], value[3])
-								: new TypedArrayConstructor(buffer);
+						hydrated[index] = ops.fromViewInfo(type, buffer, value[2], value[3]);
 
 						break;
 					}
@@ -193,11 +194,12 @@ export function unflatten(parsed, revivers) {
 						if (typeof base64 !== 'string') {
 							throw new Error('Invalid ArrayBuffer encoding');
 						}
-						const arraybuffer = decode64(base64);
-						hydrated[index] = arraybuffer;
+						hydrated[index] = ops.fromArrayBuffer(decode64(base64));
 						break;
 					}
 
+					case 'URL':
+					case 'URLSearchParams':
 					case 'Temporal.Duration':
 					case 'Temporal.Instant':
 					case 'Temporal.PlainDate':
@@ -206,21 +208,8 @@ export function unflatten(parsed, revivers) {
 					case 'Temporal.PlainMonthDay':
 					case 'Temporal.PlainYearMonth':
 					case 'Temporal.ZonedDateTime': {
-						const temporalName = type.slice(9);
-						// @ts-expect-error TS doesn't know about Temporal yet
-						hydrated[index] = Temporal[temporalName].from(value[1]);
-						break;
-					}
-
-					case 'URL': {
-						const url = new URL(value[1]);
-						hydrated[index] = url;
-						break;
-					}
-
-					case 'URLSearchParams': {
-						const url = new URLSearchParams(value[1]);
-						hydrated[index] = url;
+						// the same tags `toStringValue` serializes on the stringify side
+						hydrated[index] = ops.fromStringValue(type, value[1]);
 						break;
 					}
 
@@ -235,19 +224,11 @@ export function unflatten(parsed, revivers) {
 					throw new Error('Invalid input');
 				}
 
-				/** @type {any[]} */
-				const array = [];
+				// `len` comes from the input rather than being bounded by it, so
+				// `createSparseArray` is responsible for not allocating storage
+				// proportional to it.
+				const array = ops.createSparseArray(len);
 				hydrated[index] = array;
-
-				// Setting `array.length = len` (or equivalently calling `new Array(len)`)
-				// on an untrusted `len` is a DoS vector: V8 eagerly allocates a
-				// contiguous backing store for array lengths below ~10^8, so a
-				// small payload with a huge declared length can force arbitrary
-				// memory allocation. Touching the largest-possible index first
-				// forces V8 into dictionary-elements mode, where `length` is
-				// just a number and no contiguous allocation occurs.
-				array[MAX_ARRAY_INDEX] = undefined;
-				delete array[MAX_ARRAY_INDEX];
 
 				for (let i = 2; i < value.length; i += 2) {
 					const idx = value[i];
@@ -256,24 +237,21 @@ export function unflatten(parsed, revivers) {
 						throw new Error('Invalid input');
 					}
 
-					array[idx] = hydrate(value[i + 1]);
+					ops.set(array, idx, hydrate(value[i + 1]));
 				}
-
-				array.length = len;
 			} else {
-				const array = new Array(value.length);
+				const array = ops.createArray(value.length);
 				hydrated[index] = array;
 
 				for (let i = 0; i < value.length; i += 1) {
 					const n = value[i];
 					if (n === HOLE) continue;
 
-					array[i] = hydrate(n);
+					ops.set(array, i, hydrate(n));
 				}
 			}
 		} else {
-			/** @type {Record<string, any>} */
-			const object = {};
+			const object = ops.createObject();
 			hydrated[index] = object;
 
 			for (const key of Object.keys(value)) {
@@ -281,8 +259,7 @@ export function unflatten(parsed, revivers) {
 					throw new Error('Cannot parse an object with a `__proto__` property');
 				}
 
-				const n = value[key];
-				object[key] = hydrate(n);
+				ops.set(object, key, hydrate(value[key]));
 			}
 		}
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -9,7 +9,7 @@ import {
 	UNDEFINED
 } from './constants.js';
 import { encode64 } from './base64.js';
-import { default_operations, merge_operations } from './operations.js';
+import { default_stringify_operations, merge_operations } from './operations.js';
 
 /**
  * Turn a value into a JSON string that can be parsed with `devalue.parse`
@@ -68,7 +68,7 @@ export async function stringifyAsync(value, reducers, options) {
  * @param {import('./types.js').StringifyOptions} [options]
  */
 function run(async, value, reducers, options) {
-	const ops = merge_operations(default_operations, options?.operations);
+	const ops = merge_operations(default_stringify_operations, options?.operations);
 
 	/** @type {any[]} */
 	const stringified = [];

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -9,7 +9,7 @@ import {
 	UNDEFINED
 } from './constants.js';
 import { encode64 } from './base64.js';
-import { default_operations } from './operations.js';
+import { default_operations, merge_operations } from './operations.js';
 
 /**
  * Turn a value into a JSON string that can be parsed with `devalue.parse`
@@ -68,21 +68,7 @@ export async function stringifyAsync(value, reducers, options) {
  * @param {import('./types.js').StringifyOptions} [options]
  */
 function run(async, value, reducers, options) {
-	/** @type {import('./types.js').StringifyOperations} */
-	let ops = default_operations;
-
-	if (options?.operations) {
-		ops = /** @type {import('./types.js').StringifyOperations} */ ({});
-
-		// iterating the default keys (rather than the override's own keys) means
-		// nullish members fall back to the default, and inherited members — e.g.
-		// from a class instance — are picked up
-		for (const key of /** @type {(keyof typeof ops)[]} */ (
-			Object.keys(default_operations)
-		)) {
-			ops[key] = options.operations[key] ?? default_operations[key];
-		}
-	}
+	const ops = merge_operations(default_operations, options?.operations);
 
 	/** @type {any[]} */
 	const stringified = [];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -213,3 +213,157 @@ export interface StringifyOptions {
 	 */
 	operations?: Partial<StringifyOperations>;
 }
+
+/**
+ * The construction operations `parse` and `unflatten` perform while reviving
+ * a value. Every value the algorithm creates — primitives, built-in
+ * instances, containers — and every mutation it performs to populate those
+ * containers goes through this interface, so overriding members lets you
+ * control exactly what gets built.
+ *
+ * Use cases:
+ * - **Cross-realm revival**: construct values from the intrinsics of a
+ *   different realm (e.g. a `node:vm` context) so that the result passes
+ *   `instanceof` checks inside that realm.
+ * - **Foreign-runtime revival**: build values inside another JavaScript
+ *   runtime (a WASM-hosted engine, a remote process) by implementing the
+ *   operations over handle objects. The algorithm never inspects the values
+ *   it creates — it only passes them back into other operations — so
+ *   "value" can be any opaque token.
+ *
+ * The naming follows the same scheme as `StringifyOperations`, with the
+ * host/value-space boundary running the other way:
+ *
+ * - `fromXxx` — conversions whose input is entirely host data and whose
+ *   result crosses into value space; each is the inverse of the
+ *   corresponding `toXxx` (`fromPrimitive` / `toPrimitive`,
+ *   `fromISOString` / `toISOString`, `fromStringValue` / `toStringValue`,
+ *   `fromArrayBuffer` / `toArrayBuffer`).
+ * - `fromXxxInfo` — construction from a multi-field descriptor, the inverse
+ *   of the corresponding `xxxInfo` (`fromRegExpInfo` / `regExpInfo`,
+ *   `fromViewInfo` / `viewInfo`).
+ * - `createXxx` — empty value-space containers, populated afterwards by the
+ *   mutators. That ordering is what makes cyclic values possible: the empty
+ *   container is cached before its contents are revived.
+ * - bare verbs — value-space operations whose operands and results stay in
+ *   value space (`box` inverts `unbox`, `set` inverts `get`, `addValue`
+ *   inverts `valuesOf`, `addEntry` inverts `entriesOf`).
+ *
+ * All members are optional when passed to `parse`/`unflatten` — omitted
+ * members fall back to the defaults (native behavior, exported as
+ * `defaultParseOperations`).
+ */
+export interface ParseOperations {
+	/**
+	 * Wraps a host primitive (`string`, `number`, `boolean`, `bigint`,
+	 * `null`, `undefined`, and the special values `NaN`, `±Infinity`, `-0`)
+	 * into the representation the other operations expect. The inverse of
+	 * `toPrimitive`. Default: the value itself.
+	 */
+	fromPrimitive(
+		value: string | number | boolean | bigint | null | undefined
+	): any;
+
+	/**
+	 * Creates a `Date` from an ISO string. The inverse of `toISOString`.
+	 * An empty string represents an invalid date (as produced for
+	 * `new Date(NaN)`).
+	 */
+	fromISOString(iso: string): any;
+
+	/**
+	 * Creates a `URL`, `URLSearchParams` or `Temporal.*` value from its
+	 * string form — the same tags `toStringValue` serializes, and its
+	 * inverse. `tag` distinguishes them (e.g. `'URL'`,
+	 * `'Temporal.Instant'`).
+	 */
+	fromStringValue(tag: string, text: string): any;
+
+	/**
+	 * Creates an `ArrayBuffer` from a host `ArrayBuffer` holding the decoded
+	 * bytes. The inverse of `toArrayBuffer`. Default: the buffer itself.
+	 * Foreign-runtime implementations should copy the bytes into the target
+	 * runtime.
+	 */
+	fromArrayBuffer(buffer: ArrayBuffer): any;
+
+	/**
+	 * Creates a `RegExp` from its source and flags. The inverse of
+	 * `regExpInfo`. `flags` is `undefined` when the pattern had no flags.
+	 */
+	fromRegExpInfo(source: string, flags: string | undefined): any;
+
+	/**
+	 * Creates a typed array or `DataView` over an already-revived buffer.
+	 * The inverse of `viewInfo`. `type` is the constructor name (e.g.
+	 * `'Uint8Array'`, `'DataView'`). `byteOffset` and `length` are
+	 * `undefined` when the view spans the whole buffer; otherwise `length`
+	 * is the element count for typed arrays and the byte length for
+	 * `DataView`, matching the constructor signatures.
+	 */
+	fromViewInfo(
+		type: string,
+		buffer: any,
+		byteOffset: number | undefined,
+		length: number | undefined
+	): any;
+
+	/**
+	 * Creates a boxed primitive object (`Number`, `String`, `Boolean`,
+	 * `BigInt` wrapper) around an already-revived inner primitive. The
+	 * inverse of `unbox`. Equivalent to `Object(value)`.
+	 */
+	box(value: any): any;
+
+	/**
+	 * Creates an array of the given length, to be populated with `set`.
+	 * The length is bounded by the size of the input, so it is safe to
+	 * allocate eagerly. Indices that are never set must remain holes.
+	 */
+	createArray(length: number): any;
+
+	/**
+	 * Creates a sparse array of the given length, to be populated with
+	 * `set`. Unlike `createArray`, the length comes from the input rather
+	 * than being bounded by it, so implementations must not allocate
+	 * storage proportional to it.
+	 */
+	createSparseArray(length: number): any;
+
+	/** Creates an empty object, to be populated with `set`. */
+	createObject(): any;
+
+	/**
+	 * Creates an empty null-prototype object, to be populated with `set`.
+	 * Equivalent to `Object.create(null)`.
+	 */
+	createNullPrototypeObject(): any;
+
+	/** Creates an empty `Set`, to be populated with `addValue`. */
+	createSet(): any;
+
+	/** Creates an empty `Map`, to be populated with `addEntry`. */
+	createMap(): any;
+
+	/**
+	 * Sets an element or property on a value created by `createArray`,
+	 * `createSparseArray`, `createObject` or `createNullPrototypeObject`.
+	 * The inverse of `get`, which likewise serves both arrays and objects.
+	 */
+	set(target: any, key: string | number, value: any): void;
+
+	/** Adds a value to a `Set` created by `createSet`. The inverse of `valuesOf`. */
+	addValue(set: any, value: any): void;
+
+	/** Adds an entry to a `Map` created by `createMap`. The inverse of `entriesOf`. */
+	addEntry(map: any, key: any, value: any): void;
+}
+
+/** Options for `parse` and `unflatten`. */
+export interface ParseOptions {
+	/**
+	 * Overrides for the construction operations used while reviving.
+	 * Omitted members fall back to `defaultParseOperations`.
+	 */
+	operations?: Partial<ParseOperations>;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -177,7 +177,14 @@ export interface StringifyOperations {
 
 	/**
 	 * Returns the populated indices of a (sparse) `Array` value as strings,
-	 * in ascending order. Equivalent to `Object.keys(array)` filtered to
+	 * in ascending order.
+	 *
+	 * Implementations that already have the value's own enumerable string
+	 * keys — as a foreign-runtime implementation typically does — should pass
+	 * them through the exported `filterArrayIndices` helper rather than
+	 * reimplementing the filtering, which encodes the sparse-array heuristic.
+	 *
+	 * Equivalent to `Object.keys(array)` filtered to
 	 * valid array indices.
 	 */
 	indicesOf(array: any): string[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,30 @@
+export type StringValueTag =
+	| 'URL'
+	| 'URLSearchParams'
+	| 'Temporal.Duration'
+	| 'Temporal.Instant'
+	| 'Temporal.PlainDate'
+	| 'Temporal.PlainTime'
+	| 'Temporal.PlainDateTime'
+	| 'Temporal.PlainMonthDay'
+	| 'Temporal.PlainYearMonth'
+	| 'Temporal.ZonedDateTime';
+
+export type ViewTag =
+	| 'Int8Array'
+	| 'Uint8Array'
+	| 'Uint8ClampedArray'
+	| 'Int16Array'
+	| 'Uint16Array'
+	| 'Float16Array'
+	| 'Int32Array'
+	| 'Uint32Array'
+	| 'Float32Array'
+	| 'Float64Array'
+	| 'BigInt64Array'
+	| 'BigUint64Array'
+	| 'DataView';
+
 export type TypedArray =
 	| Int8Array
 	| Uint8Array
@@ -31,7 +58,8 @@ export type TypedArray =
  *   be any opaque token as long as the operations agree on what it means.
  *
  * All members are optional when passed to `stringify` — omitted members fall
- * back to the defaults (native behavior, exported as `defaultOperations`).
+ * back to the defaults (native behavior, exported as
+ * `defaultStringifyOperations`).
  *
  * Members are named by what they do with the value:
  * - `isXxx`/`hasXxx` — predicates returning booleans
@@ -212,11 +240,33 @@ export interface StringifyOperations {
 	get(value: any, key: string | number): any;
 }
 
+/** The native JavaScript implementation exported as `defaultStringifyOperations`. */
+export interface DefaultStringifyOperations extends StringifyOperations {
+	identify(value: any): any;
+	toPrimitive(
+		value: undefined | null | boolean | number | bigint | string
+	): undefined | null | boolean | number | bigint | string;
+	toISOString(date: Date): string;
+	regExpInfo(regexp: RegExp): { source: string; flags: string };
+	valuesOf(set: Set<any>): Set<any>;
+	entriesOf(map: Map<any, any>): Map<any, any>;
+	viewInfo(view: any): {
+		buffer: ArrayBufferLike;
+		byteOffset: number;
+		byteLength: number;
+		length?: number;
+		bufferByteLength: number;
+	};
+	toArrayBuffer(buffer: ArrayBuffer): ArrayBuffer;
+	lengthOf(array: any[]): number;
+	indicesOf(array: any[]): string[];
+}
+
 /** Options for `stringify` and `stringifyAsync`. */
 export interface StringifyOptions {
 	/**
 	 * Overrides for the introspection/extraction operations used while
-	 * serializing. Omitted members fall back to `defaultOperations`.
+	 * serializing. Omitted members fall back to `defaultStringifyOperations`.
 	 */
 	operations?: Partial<StringifyOperations>;
 }
@@ -268,7 +318,7 @@ export interface ParseOperations {
 	 * `toPrimitive`. Default: the value itself.
 	 */
 	fromPrimitive(
-		value: string | number | boolean | bigint | null | undefined
+		primitive: string | number | boolean | bigint | null | undefined
 	): any;
 
 	/**
@@ -284,7 +334,7 @@ export interface ParseOperations {
 	 * inverse. `tag` distinguishes them (e.g. `'URL'`,
 	 * `'Temporal.Instant'`).
 	 */
-	fromStringValue(tag: string, text: string): any;
+	fromStringValue(tag: StringValueTag, text: string): any;
 
 	/**
 	 * Creates an `ArrayBuffer` from a host `ArrayBuffer` holding the decoded
@@ -302,14 +352,14 @@ export interface ParseOperations {
 
 	/**
 	 * Creates a typed array or `DataView` over an already-revived buffer.
-	 * The inverse of `viewInfo`. `type` is the constructor name (e.g.
+	 * The inverse of `viewInfo`. `tag` is the constructor name (e.g.
 	 * `'Uint8Array'`, `'DataView'`). `byteOffset` and `length` are
 	 * `undefined` when the view spans the whole buffer; otherwise `length`
 	 * is the element count for typed arrays and the byte length for
 	 * `DataView`, matching the constructor signatures.
 	 */
 	fromViewInfo(
-		type: string,
+		tag: ViewTag,
 		buffer: any,
 		byteOffset: number | undefined,
 		length: number | undefined
@@ -364,6 +414,32 @@ export interface ParseOperations {
 
 	/** Adds an entry to a `Map` created by `createMap`. The inverse of `entriesOf`. */
 	addEntry(map: any, key: any, value: any): void;
+}
+
+/** The native JavaScript implementation exported as `defaultParseOperations`. */
+export interface DefaultParseOperations extends ParseOperations {
+	fromPrimitive(
+		primitive: string | number | boolean | bigint | null | undefined
+	): string | number | boolean | bigint | null | undefined;
+	fromISOString(iso: string): Date;
+	fromStringValue(tag: StringValueTag, text: string): URL | URLSearchParams | object;
+	fromArrayBuffer(buffer: ArrayBuffer): ArrayBuffer;
+	fromRegExpInfo(source: string, flags: string | undefined): RegExp;
+	fromViewInfo(
+		tag: ViewTag,
+		buffer: ArrayBufferLike,
+		byteOffset: number | undefined,
+		length: number | undefined
+	): TypedArray | DataView;
+	box(value: any): object;
+	createArray(length: number): any[];
+	createSparseArray(length: number): any[];
+	createObject(): Record<string, any>;
+	createNullPrototypeObject(): Record<string, any>;
+	createSet(): Set<any>;
+	createMap(): Map<any, any>;
+	addValue(set: Set<any>, value: any): void;
+	addEntry(map: Map<any, any>, key: any, value: any): void;
 }
 
 /** Options for `parse` and `unflatten`. */

--- a/src/utils.js
+++ b/src/utils.js
@@ -145,16 +145,41 @@ function is_valid_array_index_string(s) {
 }
 
 /**
- * Finds the populated indices of an array.
- * @param {unknown[]} array
+ * Returns the length of the leading run of valid array indices in `keys`.
+ * @param {string[]} keys
  */
-export function valid_array_indices(array) {
-	const keys = Object.keys(array);
+function array_index_cut(keys) {
 	for (var i = keys.length - 1; i >= 0; i--) {
 		if (is_valid_array_index_string(keys[i])) {
 			break;
 		}
 	}
-	keys.length = i + 1;
+	return i + 1;
+}
+
+/**
+ * Finds the populated indices of an array.
+ * @param {unknown[]} array
+ */
+export function valid_array_indices(array) {
+	const keys = Object.keys(array);
+	keys.length = array_index_cut(keys);
 	return keys;
+}
+
+/**
+ * Given the own enumerable string keys of an array-like value, in property
+ * order, returns the leading run of them that are valid array indices.
+ *
+ * This is the filtering half of the `arrayIndices` stringify operation,
+ * exposed so that custom operations — which typically already have the keys
+ * in hand, e.g. from a foreign runtime — don't have to reimplement it.
+ *
+ * Does not modify `keys`.
+ *
+ * @param {string[]} keys
+ * @returns {string[]}
+ */
+export function filter_array_indices(keys) {
+	return keys.slice(0, array_index_cut(keys));
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,7 +146,7 @@ function is_valid_array_index_string(s) {
 
 /**
  * Returns the length of the leading run of valid array indices in `keys`.
- * @param {string[]} keys
+ * @param {readonly string[]} keys
  */
 function array_index_cut(keys) {
 	for (var i = keys.length - 1; i >= 0; i--) {
@@ -171,13 +171,13 @@ export function valid_array_indices(array) {
  * Given the own enumerable string keys of an array-like value, in property
  * order, returns the leading run of them that are valid array indices.
  *
- * This is the filtering half of the `arrayIndices` stringify operation,
+ * This is the filtering half of the `indicesOf` stringify operation,
  * exposed so that custom operations — which typically already have the keys
  * in hand, e.g. from a foreign runtime — don't have to reimplement it.
  *
  * Does not modify `keys`.
  *
- * @param {string[]} keys
+ * @param {readonly string[]} keys
  * @returns {string[]}
  */
 export function filter_array_indices(keys) {

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -3,7 +3,7 @@ import * as uvu from 'uvu';
 import {
 	stringify,
 	stringifyAsync,
-	defaultOperations,
+	defaultStringifyOperations,
 	filterArrayIndices,
 	parse
 } from '../index.js';
@@ -55,7 +55,7 @@ suite('operations option', (test) => {
 				operations: {
 					get: undefined,
 					toISOString: undefined,
-					tagOf: (value) => defaultOperations.tagOf(value)
+					tagOf: (value) => defaultStringifyOperations.tagOf(value)
 				}
 			}
 		);
@@ -71,7 +71,7 @@ suite('operations option', (test) => {
 				get: undefined,
 				// @ts-expect-error null is not a valid override, but coalesces
 				toISOString: null,
-				tagOf: (thing) => defaultOperations.tagOf(thing)
+				tagOf: (thing) => defaultStringifyOperations.tagOf(thing)
 			}
 		});
 
@@ -94,18 +94,18 @@ suite('operations option', (test) => {
 		assert.equal(result, '[["Date","custom:1700000000000"]]');
 	});
 
-	test('defaultOperations and shapeOf sentinels are frozen', () => {
-		assert.ok(Object.isFrozen(defaultOperations));
-		assert.ok(Object.isFrozen(defaultOperations.shapeOf(new Map())));
+	test('defaultStringifyOperations and shapeOf sentinels are frozen', () => {
+		assert.ok(Object.isFrozen(defaultStringifyOperations));
+		assert.ok(Object.isFrozen(defaultStringifyOperations.shapeOf(new Map())));
 		assert.ok(
-			Object.isFrozen(defaultOperations.shapeOf({ [Symbol('key')]: 1 }))
+			Object.isFrozen(defaultStringifyOperations.shapeOf({ [Symbol('key')]: 1 }))
 		);
 	});
 
-	test('defaultOperations is exported and delegable', () => {
+	test('defaultStringifyOperations is exported and delegable', () => {
 		const result = stringify(new Map([['k', 'v']]), undefined, {
 			operations: {
-				entriesOf: (value) => defaultOperations.entriesOf(value)
+				entriesOf: (value) => defaultStringifyOperations.entriesOf(value)
 			}
 		});
 
@@ -128,13 +128,13 @@ suite('operations option', (test) => {
 		/** @type {import('../src/types.js').StringifyOperations['shapeOf']} */
 		const shapeOf = (value) =>
 			value instanceof Wrapper
-				? defaultOperations.shapeOf(value.inner)
-				: defaultOperations.shapeOf(value);
+				? defaultStringifyOperations.shapeOf(value.inner)
+				: defaultStringifyOperations.shapeOf(value);
 
 		const result = stringify([a, b], undefined, {
 			operations: {
 				identify: (value) => (value instanceof Wrapper ? value.inner : value),
-				tagOf: (value) => (value instanceof Wrapper ? 'Object' : defaultOperations.tagOf(value)),
+				tagOf: (value) => (value instanceof Wrapper ? 'Object' : defaultStringifyOperations.tagOf(value)),
 				shapeOf,
 				get: (value, key) =>
 					value instanceof Wrapper ? value.inner[key] : value[key]
@@ -345,24 +345,24 @@ const handle_operations = {
 		return value === null ? 'null' : typeof value;
 	},
 	toPrimitive: (handle) => raw(handle),
-	tagOf: (handle) => defaultOperations.tagOf(raw(handle)),
+	tagOf: (handle) => defaultStringifyOperations.tagOf(raw(handle)),
 	isThenable: (handle) => typeof raw(handle).then === 'function',
 	toPromise: (handle) => Promise.resolve(raw(handle)).then(h),
 	unbox: (handle) => h(raw(handle).valueOf()),
-	toISOString: (handle) => defaultOperations.toISOString(raw(handle)),
+	toISOString: (handle) => defaultStringifyOperations.toISOString(raw(handle)),
 	toStringValue: (handle) => raw(handle).toString(),
-	regExpInfo: (handle) => defaultOperations.regExpInfo(raw(handle)),
+	regExpInfo: (handle) => defaultStringifyOperations.regExpInfo(raw(handle)),
 	valuesOf: (handle) => [...raw(handle)].map(h),
 	entriesOf: (handle) => [...raw(handle)].map(([k, v]) => [h(k), h(v)]),
 	viewInfo: (handle) => {
-		const info = defaultOperations.viewInfo(raw(handle));
+		const info = defaultStringifyOperations.viewInfo(raw(handle));
 		return { ...info, buffer: h(info.buffer) };
 	},
 	toArrayBuffer: (handle) => raw(handle),
 	lengthOf: (handle) => raw(handle).length,
 	hasOwn: (handle, index) => Object.hasOwn(raw(handle), index),
-	indicesOf: (handle) => defaultOperations.indicesOf(raw(handle)),
-	shapeOf: (handle) => defaultOperations.shapeOf(raw(handle)),
+	indicesOf: (handle) => defaultStringifyOperations.indicesOf(raw(handle)),
+	shapeOf: (handle) => defaultStringifyOperations.shapeOf(raw(handle)),
 	get: (handle, key) => h(raw(handle)[key])
 };
 
@@ -569,24 +569,24 @@ const tripwire_operations = {
 		return raw === null ? 'null' : typeof raw;
 	},
 	toPrimitive: (value) => untrip(value),
-	tagOf: (value) => defaultOperations.tagOf(untrip(value)),
+	tagOf: (value) => defaultStringifyOperations.tagOf(untrip(value)),
 	isThenable: (value) => typeof untrip(value).then === 'function',
 	toPromise: (value) => Promise.resolve(untrip(value)).then(tripwire),
 	unbox: (value) => tripwire(untrip(value).valueOf()),
-	toISOString: (value) => defaultOperations.toISOString(untrip(value)),
+	toISOString: (value) => defaultStringifyOperations.toISOString(untrip(value)),
 	toStringValue: (value) => untrip(value).toString(),
-	regExpInfo: (value) => defaultOperations.regExpInfo(untrip(value)),
+	regExpInfo: (value) => defaultStringifyOperations.regExpInfo(untrip(value)),
 	valuesOf: (value) => [...untrip(value)].map(tripwire),
 	entriesOf: (value) => [...untrip(value)].map(([k, v]) => [tripwire(k), tripwire(v)]),
 	viewInfo: (value) => {
-		const info = defaultOperations.viewInfo(untrip(value));
+		const info = defaultStringifyOperations.viewInfo(untrip(value));
 		return { ...info, buffer: tripwire(info.buffer) };
 	},
 	toArrayBuffer: (value) => untrip(value),
 	lengthOf: (value) => untrip(value).length,
 	hasOwn: (value, key) => Object.hasOwn(untrip(value), key),
-	indicesOf: (value) => defaultOperations.indicesOf(untrip(value)),
-	shapeOf: (value) => defaultOperations.shapeOf(untrip(value)),
+	indicesOf: (value) => defaultStringifyOperations.indicesOf(untrip(value)),
+	shapeOf: (value) => defaultStringifyOperations.shapeOf(untrip(value)),
 	get: (value, key) => tripwire(untrip(value)[key])
 };
 
@@ -724,7 +724,7 @@ suite('filterArrayIndices', (test) => {
 		array.extra = 'x';
 		assert.equal(
 			filterArrayIndices(Object.keys(array)),
-			defaultOperations.indicesOf(array)
+			defaultStringifyOperations.indicesOf(array)
 		);
 	});
 });

--- a/test/operations.test.js
+++ b/test/operations.test.js
@@ -1,6 +1,12 @@
 import * as assert from 'uvu/assert';
 import * as uvu from 'uvu';
-import { stringify, stringifyAsync, defaultOperations, parse } from '../index.js';
+import {
+	stringify,
+	stringifyAsync,
+	defaultOperations,
+	filterArrayIndices,
+	parse
+} from '../index.js';
 
 globalThis.Temporal ??= (await import('@js-temporal/polyfill')).Temporal;
 
@@ -680,5 +686,45 @@ suite('tripwire operations (value is never touched)', (test) => {
 
 		assert.throws(() => stringify(tripwire({ a: 1 })), /value touched directly/);
 		assert.ok(tripwire_violations.length > 0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// filterArrayIndices helper
+// ---------------------------------------------------------------------------
+
+suite('filterArrayIndices', (test) => {
+	test('keeps the leading run of valid array indices', () => {
+		assert.equal(filterArrayIndices(['0', '1', '2']), ['0', '1', '2']);
+		assert.equal(filterArrayIndices(['0', '2', '7']), ['0', '2', '7']);
+		assert.equal(filterArrayIndices([]), []);
+	});
+
+	test('trims trailing non-index keys', () => {
+		assert.equal(filterArrayIndices(['0', '1', 'extra']), ['0', '1']);
+		assert.equal(filterArrayIndices(['0', 'a', 'b']), ['0']);
+		assert.equal(filterArrayIndices(['a', 'b']), []);
+	});
+
+	test('rejects index-like strings that are not valid indices', () => {
+		assert.equal(filterArrayIndices(['0', '01']), ['0']);
+		assert.equal(filterArrayIndices(['0', '-1']), ['0']);
+		assert.equal(filterArrayIndices(['0', '1.5']), ['0']);
+		assert.equal(filterArrayIndices(['0', '4294967295']), ['0']);
+	});
+
+	test('does not modify the input', () => {
+		const keys = ['0', '1', 'extra'];
+		filterArrayIndices(keys);
+		assert.equal(keys, ['0', '1', 'extra']);
+	});
+
+	test('matches the default operation for the same value', () => {
+		const array = [1, 2, 3];
+		array.extra = 'x';
+		assert.equal(
+			filterArrayIndices(Object.keys(array)),
+			defaultOperations.indicesOf(array)
+		);
 	});
 });

--- a/test/parse-operations.test.js
+++ b/test/parse-operations.test.js
@@ -1,0 +1,452 @@
+import * as vm from 'vm';
+import * as assert from 'uvu/assert';
+import * as uvu from 'uvu';
+import {
+	stringify,
+	parse,
+	unflatten,
+	defaultParseOperations,
+	defaultOperations
+} from '../index.js';
+
+globalThis.Temporal ??= (await import('@js-temporal/polyfill')).Temporal;
+
+/**
+ * @param {string} name
+ * @param {(test: import('uvu').Test) => void} fn
+ */
+function suite(name, fn) {
+	const test = uvu.suite(name);
+	fn(test);
+	test.run();
+}
+
+// ---------------------------------------------------------------------------
+// Basic plumbing
+// ---------------------------------------------------------------------------
+
+suite('parse operations option', (test) => {
+	test('partial overrides merge over defaults', () => {
+		let calls = 0;
+
+		const result = parse(stringify({ a: 1, b: [2, 3] }), undefined, {
+			operations: {
+				set(object, key, value) {
+					calls += 1;
+					object[key] = value;
+				}
+			}
+		});
+
+		assert.equal(result, { a: 1, b: [2, 3] });
+		// `set` serves objects and arrays alike (the inverse of `get`):
+		// a, b, b[0], b[1]
+		assert.equal(calls, 4);
+	});
+
+	test('explicitly-undefined overrides fall back to defaults', () => {
+		const result = parse(stringify({ a: 1, when: new Date(1700000000000) }), undefined, {
+			operations: {
+				fromISOString: undefined,
+				set: undefined,
+				createObject: () => ({})
+			}
+		});
+
+		assert.equal(result, { a: 1, when: new Date(1700000000000) });
+	});
+
+	test('defaultParseOperations is exported, frozen and delegable', () => {
+		assert.ok(Object.isFrozen(defaultParseOperations));
+
+		const result = parse(stringify(new Map([['k', 'v']])), undefined, {
+			operations: {
+				createMap: () => defaultParseOperations.createMap()
+			}
+		});
+
+		assert.equal(result, new Map([['k', 'v']]));
+	});
+
+	test('unflatten accepts operations too', () => {
+		const result = unflatten([['Date', '2023-11-14T22:13:20.000Z']], undefined, {
+			operations: {
+				fromISOString: (iso) => `date:${iso}`
+			}
+		});
+
+		assert.equal(result, 'date:2023-11-14T22:13:20.000Z');
+	});
+
+	test('revivers compose with custom operations', () => {
+		class Vector {
+			constructor(x, y) {
+				this.x = x;
+				this.y = y;
+			}
+		}
+
+		let created = 0;
+
+		const serialized = stringify(new Vector(30, 40), {
+			Vector: (value) => value instanceof Vector && [value.x, value.y]
+		});
+
+		const revived = parse(
+			serialized,
+			{ Vector: ([x, y]) => new Vector(x, y) },
+			{
+				operations: {
+					createArray(length) {
+						created += 1;
+						return new Array(length);
+					}
+				}
+			}
+		);
+
+		assert.ok(revived instanceof Vector);
+		assert.equal(revived.x, 30);
+		assert.equal(revived.y, 40);
+		// the reviver's payload array went through the custom operation
+		assert.equal(created, 1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sparse array DoS protection is preserved through the operation boundary
+// ---------------------------------------------------------------------------
+
+suite('sparse arrays', (test) => {
+	test('createSparseArray produces the declared length without eager allocation', () => {
+		// A tiny payload declaring a huge length must not allocate.
+		const revived = unflatten([[-7, 50_000_000, 3, 1], 'x']);
+
+		assert.equal(revived.length, 50_000_000);
+		assert.equal(revived[3], 'x');
+		assert.equal(Object.keys(revived), ['3']);
+	});
+
+	test('createSparseArray override receives the declared length', () => {
+		/** @type {number[]} */
+		const lengths = [];
+
+		unflatten([[-7, 1234, 3, 1], 'x'], undefined, {
+			operations: {
+				createSparseArray(length) {
+					lengths.push(length);
+					return defaultParseOperations.createSparseArray(length);
+				}
+			}
+		});
+
+		assert.equal(lengths, [1234]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cross-realm revival (node:vm)
+// ---------------------------------------------------------------------------
+
+suite('cross-realm operations', (test) => {
+	// Note: `URL`/`URLSearchParams` are Node globals rather than ECMAScript
+	// intrinsics, so a bare vm context has none to construct from — only the
+	// ES intrinsics are exercised here.
+	/** @returns {Partial<import('../src/types.js').ParseOperations>} */
+	function realm_operations(context) {
+		const intrinsics = vm.runInContext(
+			`({
+				Date, RegExp, Set, Map, Object, Array,
+				createObject: () => ({}),
+				createNullPrototypeObject: () => Object.create(null)
+			})`,
+			context
+		);
+
+		return {
+			fromISOString: (iso) => new intrinsics.Date(iso),
+			fromRegExpInfo: (source, flags) => new intrinsics.RegExp(source, flags),
+			createSet: () => new intrinsics.Set(),
+			createMap: () => new intrinsics.Map(),
+			createObject: () => intrinsics.createObject(),
+			createNullPrototypeObject: () => intrinsics.createNullPrototypeObject(),
+			createArray: (length) => new intrinsics.Array(length),
+			fromViewInfo: (type, buffer, byteOffset, length) => {
+				const Constructor = vm.runInContext(type, context);
+				return byteOffset !== undefined
+					? new Constructor(buffer, byteOffset, length)
+					: new Constructor(buffer);
+			},
+			fromArrayBuffer: (buffer) => {
+				const target = new (vm.runInContext('ArrayBuffer', context))(buffer.byteLength);
+				new (vm.runInContext('Uint8Array', context))(target).set(new Uint8Array(buffer));
+				return target;
+			}
+		};
+	}
+
+	test('values are constructed with the target realm intrinsics', () => {
+		const context = vm.createContext({});
+		const operations = realm_operations(context);
+
+		const value = {
+			when: new Date(1700000000000),
+			pattern: /ab+c/gi,
+			set: new Set([1, 2]),
+			map: new Map([['k', 'v']]),
+			list: [1, 2, 3],
+			bare: Object.assign(Object.create(null), { x: 1 })
+		};
+
+		const revived = parse(stringify(value), undefined, { operations });
+
+		// Correct values...
+		assert.equal(revived.when.toISOString(), '2023-11-14T22:13:20.000Z');
+		assert.equal(revived.pattern.source, 'ab+c');
+		assert.equal(revived.pattern.flags, 'gi');
+		assert.equal([...revived.set], [1, 2]);
+		// entries are flattened to primitives: the inner arrays belong to the
+		// other realm, so a structural comparison would fail on the prototype
+		assert.equal(
+			[...revived.map].map(([k, v]) => `${k}=${v}`),
+			['k=v']
+		);
+		assert.equal([...revived.list], [1, 2, 3]);
+		assert.equal(revived.bare.x, 1);
+
+		// ...built from the *other* realm's intrinsics, so host `instanceof`
+		// fails while the sandbox's own checks succeed.
+		assert.not.ok(revived.when instanceof Date);
+		assert.not.ok(revived.list instanceof Array);
+
+		context.probe = revived;
+		assert.ok(
+			vm.runInContext(
+				`probe.when instanceof Date &&
+				 probe.pattern instanceof RegExp &&
+				 probe.set instanceof Set &&
+				 probe.map instanceof Map &&
+				 Array.isArray(probe.list) &&
+				 Object.getPrototypeOf(probe.bare) === null`,
+				context
+			)
+		);
+	});
+
+	test('typed arrays are constructed in the target realm', () => {
+		const context = vm.createContext({});
+		const operations = realm_operations(context);
+
+		const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+		const revived = parse(stringify(bytes), undefined, { operations });
+
+		assert.equal([...revived], [1, 2, 3, 4, 5, 6, 7, 8]);
+		assert.not.ok(revived instanceof Uint8Array);
+
+		context.probe = revived;
+		assert.ok(
+			vm.runInContext(
+				'probe instanceof Uint8Array && probe.buffer instanceof ArrayBuffer',
+				context
+			)
+		);
+	});
+
+	test('cyclic values are linked correctly across realms', () => {
+		const context = vm.createContext({});
+		const operations = realm_operations(context);
+
+		/** @type {any} */
+		const cyclic = { name: 'cycle' };
+		cyclic.self = cyclic;
+		cyclic.list = [cyclic];
+
+		const revived = parse(stringify(cyclic), undefined, { operations });
+
+		assert.equal(revived.self, revived);
+		assert.equal(revived.list[0], revived);
+
+		context.probe = revived;
+		assert.ok(
+			vm.runInContext('probe.self === probe && probe.list[0] === probe', context)
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Foreign-runtime (handle-based) revival
+// ---------------------------------------------------------------------------
+
+// A stand-in for a VM value handle (e.g. a QuickJS-in-WASM JSValueHandle).
+// `parse` never inspects the values it builds — it only feeds them back into
+// other operations — so a fully opaque wrapper is enough.
+class Handle {
+	/** @param {any} value */
+	constructor(value) {
+		this.value = value;
+	}
+}
+
+/** @param {any} value */
+const h = (value) => new Handle(value);
+
+/** @param {Handle} handle */
+const raw = (handle) => /** @type {Handle} */ (handle).value;
+
+/** @type {import('../src/types.js').ParseOperations} */
+const handle_operations = {
+	fromPrimitive: (value) => h(value),
+	fromISOString: (iso) => h(new Date(iso)),
+	fromRegExpInfo: (source, flags) => h(new RegExp(source, flags)),
+	fromStringValue: (tag, text) => h(defaultParseOperations.fromStringValue(tag, text)),
+	box: (value) => h(Object(raw(value))),
+	fromArrayBuffer: (buffer) => h(buffer),
+	fromViewInfo: (type, buffer, byteOffset, length) =>
+		h(defaultParseOperations.fromViewInfo(type, raw(buffer), byteOffset, length)),
+	createArray: (length) => h(new Array(length)),
+	createSparseArray: (length) => h(defaultParseOperations.createSparseArray(length)),
+
+	createObject: () => h({}),
+	createNullPrototypeObject: () => h(Object.create(null)),
+	set: (target, key, value) => {
+		raw(target)[key] = raw(value);
+	},
+	createSet: () => h(new Set()),
+	addValue: (set, value) => {
+		raw(set).add(raw(value));
+	},
+	createMap: () => h(new Map()),
+	addEntry: (map, key, value) => {
+		raw(map).set(raw(key), raw(value));
+	}
+};
+
+suite('handle-based parse operations', (test) => {
+	/** @param {any} value */
+	function assert_round_trip(value) {
+		const revived = parse(stringify(value), undefined, {
+			operations: handle_operations
+		});
+
+		assert.ok(revived instanceof Handle, 'root should be a handle');
+		assert.equal(raw(revived), parse(stringify(value)));
+	}
+
+	test('primitives', () => {
+		assert_round_trip(42);
+		assert_round_trip(-0);
+		assert_round_trip(NaN);
+		assert_round_trip(Infinity);
+		assert_round_trip(-Infinity);
+		assert_round_trip('hello');
+		assert_round_trip(true);
+		assert_round_trip(null);
+		assert_round_trip(undefined);
+		assert_round_trip(123n);
+	});
+
+	test('objects, arrays and special types', () => {
+		assert_round_trip({ a: 1, nested: { b: [2, 3] } });
+		assert_round_trip([1, 'two', { three: 3 }]);
+		assert_round_trip(new Date(1700000000000));
+		assert_round_trip(/ab+c/gi);
+		assert_round_trip(new Map([['k', { v: 1 }]]));
+		assert_round_trip(new Set([1, 2, 3]));
+		assert_round_trip(new URL('https://example.com/path?q=1'));
+		assert_round_trip(new URLSearchParams('a=1&b=2'));
+		// eslint-disable-next-line no-sparse-arrays
+		assert_round_trip([1, , 3]);
+		assert_round_trip(Object.assign(Object.create(null), { x: 1 }));
+		assert_round_trip(new Number(42));
+		assert_round_trip(Temporal.Instant.from('2023-11-14T22:13:20Z'));
+	});
+
+	test('typed arrays and buffers', () => {
+		const buffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+		assert_round_trip(buffer);
+		assert_round_trip(new Uint8Array(buffer));
+		assert_round_trip(new Int16Array(buffer, 2, 2)); // subarray
+		assert_round_trip(new DataView(buffer, 1, 4));
+	});
+
+	test('repeated references share one handle-built value', () => {
+		const shared = { x: 1 };
+		const revived = parse(stringify({ first: shared, second: shared }), undefined, {
+			operations: handle_operations
+		});
+
+		const object = raw(revived);
+		assert.equal(object.first, object.second);
+	});
+
+	test('cyclic values', () => {
+		/** @type {any} */
+		const cyclic = { name: 'cycle' };
+		cyclic.self = cyclic;
+
+		const revived = parse(stringify(cyclic), undefined, {
+			operations: handle_operations
+		});
+
+		const object = raw(revived);
+		assert.equal(object.self, object);
+	});
+
+	test('revivers receive and return handles', () => {
+		class Custom {
+			constructor(inner) {
+				this.inner = inner;
+			}
+		}
+
+		const revived = parse(
+			'[["Custom",1],"yes"]',
+			{
+				Custom: (handle) => {
+					assert.ok(handle instanceof Handle);
+					return h(new Custom(raw(handle)));
+				}
+			},
+			{ operations: handle_operations }
+		);
+
+		assert.ok(revived instanceof Handle);
+		assert.ok(raw(revived) instanceof Custom);
+		assert.equal(raw(revived).inner, 'yes');
+	});
+
+	test('round-trips through both operation sets', () => {
+		// stringify a handle-wrapped value with the stringify operations from
+		// the companion feature, then revive it back into handles
+		const original = { list: [1, 2], when: new Date(1700000000000) };
+
+		/** @type {Partial<import('../src/types.js').StringifyOperations>} */
+		const stringify_ops = {
+			identify: (handle) => raw(handle),
+			typeOf: (handle) => {
+				const value = raw(handle);
+				return value === null ? 'null' : typeof value;
+			},
+			toPrimitive: (handle) => raw(handle),
+			tagOf: (handle) => defaultOperations.tagOf(raw(handle)),
+			isThenable: () => false,
+			toISOString: (handle) => defaultOperations.toISOString(raw(handle)),
+			lengthOf: (handle) => raw(handle).length,
+			hasOwn: (handle, key) => Object.hasOwn(raw(handle), key),
+			indicesOf: (handle) => defaultOperations.indicesOf(raw(handle)),
+			shapeOf: (handle) => defaultOperations.shapeOf(raw(handle)),
+			get: (handle, key) => h(raw(handle)[key])
+		};
+
+		const serialized = stringify(h(original), undefined, {
+			operations: stringify_ops
+		});
+
+		assert.equal(serialized, stringify(original));
+
+		const revived = parse(serialized, undefined, { operations: handle_operations });
+
+		assert.equal(raw(revived).list, [1, 2]);
+		assert.equal(raw(revived).when.getTime(), 1700000000000);
+	});
+});

--- a/test/parse-operations.test.js
+++ b/test/parse-operations.test.js
@@ -6,7 +6,7 @@ import {
 	parse,
 	unflatten,
 	defaultParseOperations,
-	defaultOperations
+	defaultStringifyOperations
 } from '../index.js';
 
 globalThis.Temporal ??= (await import('@js-temporal/polyfill')).Temporal;
@@ -171,8 +171,8 @@ suite('cross-realm operations', (test) => {
 			createObject: () => intrinsics.createObject(),
 			createNullPrototypeObject: () => intrinsics.createNullPrototypeObject(),
 			createArray: (length) => new intrinsics.Array(length),
-			fromViewInfo: (type, buffer, byteOffset, length) => {
-				const Constructor = vm.runInContext(type, context);
+			fromViewInfo: (tag, buffer, byteOffset, length) => {
+				const Constructor = vm.runInContext(tag, context);
 				return byteOffset !== undefined
 					? new Constructor(buffer, byteOffset, length)
 					: new Constructor(buffer);
@@ -274,6 +274,103 @@ suite('cross-realm operations', (test) => {
 });
 
 // ---------------------------------------------------------------------------
+// Constructed values are never touched directly
+// ---------------------------------------------------------------------------
+
+suite('tripwire parse operations', (test) => {
+	const values = new WeakMap();
+
+	const handler = new Proxy(
+		{},
+		{
+			get: (_, trap) => () => {
+				throw new Error(`constructed value touched via ${String(trap)}`);
+			}
+		}
+	);
+
+	/** @param {any} value */
+	function tripwire(value) {
+		const handle = new Proxy({}, handler);
+		values.set(handle, value);
+		return handle;
+	}
+
+	/** @param {any} handle */
+	function untrip(handle) {
+		if (!values.has(handle)) throw new Error('expected a tripwire handle');
+		return values.get(handle);
+	}
+
+	/** @type {import('../src/types.js').ParseOperations} */
+	const operations = {
+		fromPrimitive: (primitive) => tripwire(primitive),
+		fromISOString: (iso) => tripwire(new Date(iso)),
+		fromStringValue: (tag, text) =>
+			tripwire(defaultParseOperations.fromStringValue(tag, text)),
+		fromArrayBuffer: (buffer) => tripwire(buffer),
+		fromRegExpInfo: (source, flags) => tripwire(new RegExp(source, flags)),
+		fromViewInfo: (tag, buffer, byteOffset, length) =>
+			tripwire(
+				defaultParseOperations.fromViewInfo(
+					tag,
+					untrip(buffer),
+					byteOffset,
+					length
+				)
+			),
+		box: (value) => tripwire(Object(untrip(value))),
+		createArray: (length) => tripwire(new Array(length)),
+		createSparseArray: (length) =>
+			tripwire(defaultParseOperations.createSparseArray(length)),
+		createObject: () => tripwire({}),
+		createNullPrototypeObject: () => tripwire(Object.create(null)),
+		createSet: () => tripwire(new Set()),
+		createMap: () => tripwire(new Map()),
+		set: (target, key, value) => {
+			untrip(target)[key] = untrip(value);
+		},
+		addValue: (set, value) => {
+			untrip(set).add(untrip(value));
+		},
+		addEntry: (map, key, value) => {
+			untrip(map).set(untrip(key), untrip(value));
+		}
+	};
+
+	test('parse only passes constructed values to operations', () => {
+		const shared = { shared: true };
+		const cyclic = { shared };
+		cyclic.self = cyclic;
+
+		const input = {
+			primitive: 123n,
+			date: new Date(1700000000000),
+			url: new URL('https://example.com/path?q=1'),
+			temporal: Temporal.Instant.from('2023-11-14T22:13:20Z'),
+			regexp: /ab+c/gi,
+			buffer: new Uint8Array([1, 2, 3, 4]).buffer,
+			view: new Uint8Array([5, 6, 7, 8]),
+			boxed: new Number(42),
+			array: [shared, , cyclic],
+			sparse: Object.assign(new Array(1000), { 999: shared }),
+			object: { shared },
+			null_object: Object.assign(Object.create(null), { shared }),
+			set: new Set([shared]),
+			map: new Map([[shared, cyclic]])
+		};
+
+		const revived = parse(stringify(input), undefined, { operations });
+		const root = untrip(revived);
+
+		assert.equal(root.object.shared, root.array[0]);
+		assert.equal(root.array[2].self, root.array[2]);
+		assert.equal(root.sparse.length, 1000);
+		assert.equal(root.sparse[999], root.array[0]);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Foreign-runtime (handle-based) revival
 // ---------------------------------------------------------------------------
 
@@ -295,14 +392,14 @@ const raw = (handle) => /** @type {Handle} */ (handle).value;
 
 /** @type {import('../src/types.js').ParseOperations} */
 const handle_operations = {
-	fromPrimitive: (value) => h(value),
+	fromPrimitive: (primitive) => h(primitive),
 	fromISOString: (iso) => h(new Date(iso)),
 	fromRegExpInfo: (source, flags) => h(new RegExp(source, flags)),
 	fromStringValue: (tag, text) => h(defaultParseOperations.fromStringValue(tag, text)),
 	box: (value) => h(Object(raw(value))),
 	fromArrayBuffer: (buffer) => h(buffer),
-	fromViewInfo: (type, buffer, byteOffset, length) =>
-		h(defaultParseOperations.fromViewInfo(type, raw(buffer), byteOffset, length)),
+	fromViewInfo: (tag, buffer, byteOffset, length) =>
+		h(defaultParseOperations.fromViewInfo(tag, raw(buffer), byteOffset, length)),
 	createArray: (length) => h(new Array(length)),
 	createSparseArray: (length) => h(defaultParseOperations.createSparseArray(length)),
 
@@ -428,13 +525,13 @@ suite('handle-based parse operations', (test) => {
 				return value === null ? 'null' : typeof value;
 			},
 			toPrimitive: (handle) => raw(handle),
-			tagOf: (handle) => defaultOperations.tagOf(raw(handle)),
+			tagOf: (handle) => defaultStringifyOperations.tagOf(raw(handle)),
 			isThenable: () => false,
-			toISOString: (handle) => defaultOperations.toISOString(raw(handle)),
+			toISOString: (handle) => defaultStringifyOperations.toISOString(raw(handle)),
 			lengthOf: (handle) => raw(handle).length,
 			hasOwn: (handle, key) => Object.hasOwn(raw(handle), key),
-			indicesOf: (handle) => defaultOperations.indicesOf(raw(handle)),
-			shapeOf: (handle) => defaultOperations.shapeOf(raw(handle)),
+			indicesOf: (handle) => defaultStringifyOperations.indicesOf(raw(handle)),
+			shapeOf: (handle) => defaultStringifyOperations.shapeOf(raw(handle)),
 			get: (handle, key) => h(raw(handle)[key])
 		};
 


### PR DESCRIPTION
Stacked on #172 — the diff shown includes that PR's commits until it lands. **Review #172 first**; the parse-specific changes are in the last commit ([83f17f4](https://github.com/sveltejs/devalue/pull/173/commits)).

## Summary

The inverse of #172: where `stringify` needs pluggable **introspection**, `parse` needs pluggable **construction**.

```js
parse(serialized, revivers, { operations: { /* Partial<ParseOperations> */ } })
unflatten(parsed, revivers, { operations: { ... } })
```

Every value `parse`/`unflatten` creates while reviving — built-in instances (`Date`, `RegExp`, `URL`, `Temporal.*`, typed arrays, boxed primitives, BigInt), containers (`Map`, `Set`, arrays, objects, null-prototype objects), and the mutations that populate them — now routes through a `ParseOperations` interface. Omitted members fall back to `defaultParseOperations`, which is the current behavior extracted verbatim, so **the default path is unchanged**.

## Motivation

1. **Cross-realm revival.** Revived values are currently built from the intrinsics of whichever realm devalue runs in, so a value revived on the host and handed to a `node:vm` sandbox fails every `instanceof` check inside it. Overriding the constructors fixes that (covered by a test that asserts host `instanceof` fails while the sandbox's own checks pass).

2. **Foreign-runtime revival.** `parse` never inspects the values it creates — it only feeds them back into other operations — so implementations can build values inside another runtime (WASM-hosted engine, remote process) and return opaque handles. Combined with #172 this closes the loop: a value can be serialized out of a foreign runtime and revived back into it without either side crossing the boundary as raw data.

## Design notes

- **Create-then-populate**: containers are created empty and populated via `setAdd`/`mapSet`/`setProperty`/`setIndex`. This mirrors the existing algorithm and is what keeps cyclic values revivable (the empty container is cached before its contents are built) — documented on the interface so implementors don't "optimize" it away.
- **Two array creators.** `createArray(length)` takes a payload-bounded length; `createSparseArray(length)` takes an *untrusted* length and is contractually required not to allocate proportionally to it. This keeps the existing sparse-array DoS mitigation (V8 dictionary-elements trick) intact and, more importantly, makes the requirement explicit for anyone writing their own implementation rather than leaving it as an undocumented invariant of the call site.
  - The default implementation now sets `length` upfront instead of truncating at the end. I verified with `%HasDictionaryElements` across lengths from 10 to 5e7 that this is equivalent — both orderings stay in dictionary mode, while naive `new Array(len)` drops out below ~5e7 (the actual DoS vector).
- **No introspection ops.** All the payload validation stays host-side on the parsed JSON, so nothing in `parse` needs to *read* a revived value — the interface is purely constructive.
- **Renames `defaultOperations` → `defaultStringifyOperations`** for symmetry with `defaultParseOperations`. #172 is unreleased so this is free; happy to revert if you'd rather keep the shorter name.
- `uneval` remains out of scope.

## Tests

20 new tests in `test/parse-operations.test.js` (779 total passing; `test/operations.test.js` renamed to `test/stringify-operations.test.js`):

- plumbing: partial merging, explicitly-`undefined` fallback, frozen defaults, `unflatten` parity, reviver composition
- sparse arrays: tiny payload declaring a 50M length revives with the right length/keys without allocating; override receives the declared length
- cross-realm (`node:vm`): `Date`/`RegExp`/`Set`/`Map`/array/null-proto/typed-array construction from a sandbox's intrinsics, asserted from *inside* the sandbox; cycles link correctly across the boundary
- handle model: full `ParseOperations` implementation over an opaque wrapper, round-trip parity against plain `parse` for every supported type, shared references, cycles, revivers, plus one test that round-trips through **both** operation sets

## Performance

| | baseline | this PR |
|---|---|---|
| parse: small | 283.09 ms | 281.17 ms |
| parse: medium | 33.78 ms | 34.25 ms |
| parse: large | 33.71 ms | 32.67 ms |

Within noise. `publint` clean.